### PR TITLE
Improve `GroovyCompiler` for better compilation of Groovy scripts

### DIFF
--- a/grace-core/src/main/groovy/org/grails/compiler/injection/TraitInjectionUtils.java
+++ b/grace-core/src/main/groovy/org/grails/compiler/injection/TraitInjectionUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2023 the original author or authors.
+ * Copyright 2014-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -58,6 +58,11 @@ public final class TraitInjectionUtils {
 
     public static void processTraitsForNode(SourceUnit sourceUnit, ClassNode cNode, String artefactType, CompilationUnit compilationUnit) {
         List<TraitInjector> traitInjectors = getTraitInjectors();
+        processTraitsForNode(sourceUnit, cNode, artefactType, traitInjectors, compilationUnit);
+    }
+
+    public static void processTraitsForNode(SourceUnit sourceUnit, ClassNode cNode, String artefactType, List<TraitInjector> traitInjectors,
+            CompilationUnit compilationUnit) {
         List<TraitInjector> injectorsToUse = new ArrayList<>();
         for (TraitInjector injector : traitInjectors) {
             List<String> artefactTypes = Arrays.asList(injector.getArtefactTypes());

--- a/grace-shell/build.gradle
+++ b/grace-shell/build.gradle
@@ -28,6 +28,8 @@ configurations {
         exclude group: 'org.springframework', module: 'spring-expression'
         exclude group: 'org.springframework', module: 'spring-jcl'
         exclude group: 'org.springframework', module: 'spring-tx'
+        exclude group: 'io.micrometer', module: 'micrometer-commons'
+        exclude group: 'io.micrometer', module: 'micrometer-observation'
     }
 }
 
@@ -35,7 +37,9 @@ dependencies {
     api project(":grace-api")
     api project(":grace-bootstrap")
     api project(":grace-cli")
-    api project(":grace-core")
+    api project(":grace-core"), {
+        exclude group: "org.graceframework", module: "grace-plugin-api"
+    }
     api project(":grace-gradle-model")
     api project(":grace-util")
 
@@ -62,11 +66,13 @@ dependencies {
     implementation(libs.maven.resolver.provider) {
         exclude group: "com.google.guava", module: "guava"
         exclude group: "javax.inject", module: "javax.inject"
+        exclude group: "org.ow2.asm", module: "asm"
     }
     implementation(libs.maven.resolver.connectorBasic)
     implementation(libs.maven.resolver.impl)
     implementation(libs.maven.resolver.transportFile)
     implementation(libs.maven.resolver.transportHttp) {
+        exclude group: "com.google.code.gson", module:"gson"
         exclude group: "commons-codec", module: "commons-codec"
         exclude group: "org.slf4j", module:"jcl-over-slf4j"
     }
@@ -74,10 +80,6 @@ dependencies {
         exclude group: "javax.inject", module: "javax.inject"
     }
     runtimeOnly libs.slf4j.simple
-    runtimeOnly libs.jakarta.servlet
-    runtimeOnly project(":grace-plugin-controllers")
-    runtimeOnly project(":grace-plugin-gsp")
-    runtimeOnly project(":grace-plugin-url-mappings")
 }
 
 task syncGrailsDependenciesBom(type: Sync) {

--- a/grace-shell/src/main/groovy/org/grails/cli/compiler/ExtendedGroovyClassLoader.java
+++ b/grace-shell/src/main/groovy/org/grails/cli/compiler/ExtendedGroovyClassLoader.java
@@ -23,39 +23,25 @@ import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.URLClassLoader;
 import java.security.AccessController;
-import java.security.CodeSource;
 import java.security.PrivilegedAction;
 import java.util.ArrayList;
 import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 import groovy.lang.GroovyClassLoader;
 import org.codehaus.groovy.ast.ClassNode;
-import org.codehaus.groovy.ast.InnerClassNode;
 import org.codehaus.groovy.control.CompilationUnit;
 import org.codehaus.groovy.control.CompilerConfiguration;
-import org.codehaus.groovy.control.Phases;
 import org.codehaus.groovy.control.SourceUnit;
 import org.springframework.util.Assert;
 import org.springframework.util.FileCopyUtils;
 import org.springframework.util.StringUtils;
 
-import grails.artefact.Artefact;
-import grails.core.ArtefactHandler;
-import grails.core.ArtefactInfo;
-import grails.core.GrailsClass;
-
 import org.grails.compiler.injection.GlobalGrailsClassInjectorTransformation;
 import org.grails.compiler.injection.GlobalGrailsPluginTransformation;
-import org.grails.compiler.injection.GrailsASTUtils;
-import org.grails.compiler.injection.GrailsAwareInjectionOperation;
-import org.grails.core.artefact.DomainClassArtefactHandler;
-import org.grails.core.io.support.GrailsFactoriesLoader;
 
 /**
  * Extension of the {@link GroovyClassLoader} with support for obtaining '.class' files as
@@ -106,25 +92,6 @@ public class ExtendedGroovyClassLoader extends GroovyClassLoader {
             globalASTTransformations.add(GlobalGrailsPluginTransformation.class.getName());
             this.configuration.setDisabledGlobalASTTransformations(globalASTTransformations);
         }
-    }
-
-    @Override
-    protected CompilationUnit createCompilationUnit(CompilerConfiguration config, CodeSource source) {
-        CompilationUnit compilationUnit = super.createCompilationUnit(config, source);
-
-        compilationUnit.addPhaseOperation(getGrailsAwareInjectionOperation(compilationUnit), Phases.CANONICALIZATION);
-
-        return compilationUnit;
-    }
-
-    public static GrailsAwareInjectionOperation getGrailsAwareInjectionOperation(CompilationUnit compilationUnit) {
-        List<ArtefactHandler> artefactHandlers = GrailsFactoriesLoader.loadFactories(ArtefactHandler.class);
-
-        List<ArtefactHandler> delegatedArtefactHandlers = artefactHandlers
-                .stream().map(DelegatedArtefactHandler::new).collect(Collectors.toList());
-
-        return new GrailsAwareInjectionOperation(compilationUnit, null,
-                delegatedArtefactHandlers.toArray(new ArtefactHandler[0]));
     }
 
     @Override
@@ -290,63 +257,6 @@ public class ExtendedGroovyClassLoader extends GroovyClassLoader {
             return super.loadClass(name, resolve);
         }
 
-    }
-
-    private static class DelegatedArtefactHandler implements ArtefactHandler {
-
-        private final ArtefactHandler delegate;
-
-        DelegatedArtefactHandler(ArtefactHandler artefactHandler) {
-            this.delegate = artefactHandler;
-        }
-
-        @Override
-        public String getPluginName() {
-            return this.delegate.getPluginName();
-        }
-
-        @Override
-        public String getType() {
-            return this.delegate.getType();
-        }
-
-        @Override
-        public boolean isArtefact(ClassNode classNode) {
-            if (classNode.isEnum() || classNode.isInterface() || (classNode instanceof InnerClassNode)
-                    || classNode.isAbstract()) {
-                return false;
-            }
-            if (getType().equals(DomainClassArtefactHandler.TYPE)) {
-                return GrailsASTUtils.hasAnnotation(classNode, Artefact.class);
-            }
-            String name = classNode.getName();
-            return name.endsWith(getType());
-        }
-
-        @Override
-        public boolean isArtefact(Class<?> aClass) {
-            return true;
-        }
-
-        @Override
-        public GrailsClass newArtefactClass(Class<?> artefactClass) {
-            return null;
-        }
-
-        @Override
-        public void initialize(ArtefactInfo artefacts) {
-
-        }
-
-        @Override
-        public GrailsClass getArtefactForFeature(Object feature) {
-            return null;
-        }
-
-        @Override
-        public boolean isArtefactGrailsClass(GrailsClass artefactGrailsClass) {
-            return false;
-        }
     }
 
 }

--- a/grace-shell/src/main/groovy/org/grails/cli/compiler/GrailsArtefactClassTransformation.java
+++ b/grace-shell/src/main/groovy/org/grails/cli/compiler/GrailsArtefactClassTransformation.java
@@ -1,0 +1,158 @@
+/*
+ * Copyright 2022-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.grails.cli.compiler;
+
+import java.net.URLClassLoader;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import groovy.lang.GroovyClassLoader;
+import groovy.transform.CompilationUnitAware;
+import org.codehaus.groovy.ast.ASTNode;
+import org.codehaus.groovy.ast.AnnotationNode;
+import org.codehaus.groovy.ast.ClassHelper;
+import org.codehaus.groovy.ast.ClassNode;
+import org.codehaus.groovy.ast.InnerClassNode;
+import org.codehaus.groovy.ast.ModuleNode;
+import org.codehaus.groovy.ast.expr.ConstantExpression;
+import org.codehaus.groovy.control.CompilationUnit;
+import org.codehaus.groovy.control.CompilePhase;
+import org.codehaus.groovy.control.SourceUnit;
+import org.codehaus.groovy.transform.ASTTransformation;
+import org.codehaus.groovy.transform.GroovyASTTransformation;
+
+import grails.artefact.Artefact;
+import grails.compiler.ast.ClassInjector;
+import grails.compiler.traits.TraitInjector;
+import grails.core.ArtefactHandler;
+import grails.core.ArtefactInfo;
+import grails.core.GrailsClass;
+import org.grails.compiler.injection.ArtefactTypeAstTransformation;
+import org.grails.compiler.injection.GrailsASTUtils;
+import org.grails.compiler.injection.TraitInjectionUtils;
+import org.grails.core.artefact.DomainClassArtefactHandler;
+import org.grails.core.io.support.GrailsFactoriesLoader;
+
+/**
+ * {@link ASTTransformation} for applying Grails' transformations to the Grails Artefacts.
+ *
+ * @author Michael Yan
+ * @since 2024.0.0
+ */
+@GroovyASTTransformation(phase = CompilePhase.CANONICALIZATION)
+public class GrailsArtefactClassTransformation implements ASTTransformation, CompilationUnitAware {
+
+    private static final ClassNode ARTEFACT_CLASS_NODE = ClassHelper.make(Artefact.class);
+
+    private final GroovyClassLoader loader;
+    private CompilationUnit compilationUnit;
+
+    public GrailsArtefactClassTransformation(GroovyClassLoader loader) {
+        this.loader = loader;
+    }
+
+    @Override
+    public void setCompilationUnit(final CompilationUnit compilationUnit) {
+        this.compilationUnit = compilationUnit;
+    }
+
+    @Override
+    public void visit(ASTNode[] nodes, SourceUnit source) {
+        URLClassLoader urlClassLoader = new URLClassLoader(this.loader.getURLs(), Thread.currentThread().getContextClassLoader());
+        List<ArtefactHandler> artefactHandlers = GrailsFactoriesLoader.loadFactories(ArtefactHandler.class, urlClassLoader);
+        List<ClassInjector> classInjectors = GrailsFactoriesLoader.loadFactories(ClassInjector.class, urlClassLoader);
+        List<TraitInjector> traitInjectors = GrailsFactoriesLoader.loadFactories(TraitInjector.class, urlClassLoader);
+
+        List<ArtefactHandler> delegatedArtefactHandlers = artefactHandlers
+                .stream().map(DelegatedArtefactHandler::new).collect(Collectors.toList());
+
+        ModuleNode ast = source.getAST();
+        List<ClassNode> classNodes = new ArrayList<>(ast.getClasses());
+        for (ClassNode classNode : classNodes) {
+            for (ArtefactHandler handler : delegatedArtefactHandlers) {
+                if (handler.isArtefact(classNode)) {
+                    if (classNode.getAnnotations(ARTEFACT_CLASS_NODE).isEmpty()) {
+                        AnnotationNode annotationNode = new AnnotationNode(new ClassNode(Artefact.class));
+                        annotationNode.addMember("value", new ConstantExpression(handler.getType()));
+                        classNode.addAnnotation(annotationNode);
+
+                        ArtefactTypeAstTransformation.performInjection(source, classNode, classInjectors, this.compilationUnit);
+                        TraitInjectionUtils.processTraitsForNode(source, classNode, handler.getType(), traitInjectors, this.compilationUnit);
+                    }
+                }
+            }
+        }
+    }
+
+    private static class DelegatedArtefactHandler implements ArtefactHandler {
+
+        private final ArtefactHandler delegate;
+
+        DelegatedArtefactHandler(ArtefactHandler artefactHandler) {
+            this.delegate = artefactHandler;
+        }
+
+        @Override
+        public String getPluginName() {
+            return this.delegate.getPluginName();
+        }
+
+        @Override
+        public String getType() {
+            return this.delegate.getType();
+        }
+
+        @Override
+        public boolean isArtefact(ClassNode classNode) {
+            if (classNode.isEnum() || classNode.isInterface() || (classNode instanceof InnerClassNode)
+                    || classNode.isAbstract()) {
+                return false;
+            }
+            if (getType().equals(DomainClassArtefactHandler.TYPE)) {
+                return GrailsASTUtils.hasAnnotation(classNode, Artefact.class);
+            }
+            String name = classNode.getName();
+            return name.endsWith(getType());
+        }
+
+        @Override
+        public boolean isArtefact(Class<?> aClass) {
+            return true;
+        }
+
+        @Override
+        public GrailsClass newArtefactClass(Class<?> artefactClass) {
+            return null;
+        }
+
+        @Override
+        public void initialize(ArtefactInfo artefacts) {
+
+        }
+
+        @Override
+        public GrailsClass getArtefactForFeature(Object feature) {
+            return null;
+        }
+
+        @Override
+        public boolean isArtefactGrailsClass(GrailsClass artefactGrailsClass) {
+            return false;
+        }
+    }
+
+}

--- a/grace-shell/src/main/groovy/org/grails/cli/compiler/GroovyCompiler.java
+++ b/grace-shell/src/main/groovy/org/grails/cli/compiler/GroovyCompiler.java
@@ -25,6 +25,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.ServiceLoader;
 
+import groovy.grape.GrabAnnotationTransformation;
 import groovy.grape.GrapeEngine;
 import groovy.lang.GroovyClassLoader;
 import groovy.lang.GroovyClassLoader.ClassCollector;
@@ -35,7 +36,6 @@ import org.codehaus.groovy.classgen.GeneratorContext;
 import org.codehaus.groovy.control.CompilationFailedException;
 import org.codehaus.groovy.control.CompilationUnit;
 import org.codehaus.groovy.control.CompilePhase;
-import org.codehaus.groovy.control.CompilerConfiguration;
 import org.codehaus.groovy.control.Phases;
 import org.codehaus.groovy.control.SourceUnit;
 import org.codehaus.groovy.control.customizers.CompilationCustomizer;
@@ -80,6 +80,8 @@ public class GroovyCompiler {
 
     private final ExtendedGroovyClassLoader loader;
 
+    private final CompilationUnit compilationUnit;
+
     private final Iterable<CompilerAutoConfiguration> compilerAutoConfigurations;
 
     private final List<ASTTransformation> transformations;
@@ -103,6 +105,8 @@ public class GroovyCompiler {
 
         this.loader.setDisabledGlobalASTTransformations(true);
         this.loader.getConfiguration().addCompilationCustomizers(new CompilerAutoConfigureCustomizer());
+        this.compilationUnit = new CompilationUnit(this.loader.getConfiguration(), null, this.loader);
+
         if (configuration.isAutoconfigure()) {
             this.compilerAutoConfigurations = ServiceLoader.load(CompilerAutoConfiguration.class);
         }
@@ -121,6 +125,14 @@ public class GroovyCompiler {
         for (ASTTransformation transformation : ServiceLoader.load(SpringBootAstTransformation.class)) {
             this.transformations.add(transformation);
         }
+
+        GrabAnnotationTransformation grabAnnotationTransformation = new GrabAnnotationTransformation();
+        grabAnnotationTransformation.setCompilationUnit(this.compilationUnit);
+        GrailsArtefactClassTransformation grailsArtefactClassTransformation = new GrailsArtefactClassTransformation(this.loader);
+        grailsArtefactClassTransformation.setCompilationUnit(compilationUnit);
+
+        this.transformations.add(grabAnnotationTransformation);
+        this.transformations.add(grailsArtefactClassTransformation);
         this.transformations.sort(AnnotationAwareOrderComparator.INSTANCE);
     }
 
@@ -181,9 +193,6 @@ public class GroovyCompiler {
         this.loader.clearCache();
         List<Class<?>> classes = new ArrayList<>();
 
-        CompilerConfiguration configuration = this.loader.getConfiguration();
-
-        CompilationUnit compilationUnit = new CompilationUnit(configuration, null, this.loader);
         ClassCollector collector = this.loader.createCollector(compilationUnit, null);
         compilationUnit.setClassgenCallback(collector);
 
@@ -195,7 +204,6 @@ public class GroovyCompiler {
         }
 
         addAstTransformations(compilationUnit);
-        addGrailsAwareInjectionOperation(compilationUnit);
         compilationUnit.compile(Phases.CLASS_GENERATION);
         for (Object loadedClass : collector.getLoadedClasses()) {
             classes.add((Class<?>) loadedClass);
@@ -246,10 +254,6 @@ public class GroovyCompiler {
                 }
             }
         });
-    }
-
-    private void addGrailsAwareInjectionOperation(CompilationUnit compilationUnit) {
-        compilationUnit.addPhaseOperation(ExtendedGroovyClassLoader.getGrailsAwareInjectionOperation(compilationUnit), Phases.CANONICALIZATION);
     }
 
     private int getIndexOfASTTransformationVisitor(List<?> conversionOperations) {

--- a/grace-shell/src/main/groovy/org/grails/cli/compiler/autoconfigure/GrailsGormCompilerAutoConfiguration.java
+++ b/grace-shell/src/main/groovy/org/grails/cli/compiler/autoconfigure/GrailsGormCompilerAutoConfiguration.java
@@ -46,7 +46,6 @@ public class GrailsGormCompilerAutoConfiguration extends CompilerAutoConfigurati
 
     @Override
     public void applyImports(ImportCustomizer imports) {
-        imports.addImports("grails.persistence.Entity");
         imports.addStarImports("grails.gorm.annotation", "grails.gorm.services", "grails.gorm.transactions");
     }
 

--- a/grace-shell/src/main/groovy/org/grails/cli/compiler/grape/MavenResolverGrapeEngine.java
+++ b/grace-shell/src/main/groovy/org/grails/cli/compiler/grape/MavenResolverGrapeEngine.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2023 the original author or authors.
+ * Copyright 2012-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -47,6 +47,7 @@ import org.eclipse.aether.util.filter.DependencyFilterUtils;
  *
  * @author Andy Wilkinson
  * @author Phillip Webb
+ * @author Michael Yan
  * @since 2022.1.0
  */
 @SuppressWarnings("rawtypes")
@@ -208,8 +209,11 @@ public class MavenResolverGrapeEngine implements GrapeEngine {
     }
 
     private GroovyClassLoader getClassLoader(Map args) {
-        GroovyClassLoader classLoader = (GroovyClassLoader) args.get("classLoader");
-        return (classLoader != null) ? classLoader : this.classLoader;
+        Object groovyClassLoader = args.get("classLoader");
+        if (groovyClassLoader != null && groovyClassLoader instanceof GroovyClassLoader) {
+            return (GroovyClassLoader) groovyClassLoader;
+        }
+        return this.classLoader;
     }
 
     @Override


### PR DESCRIPTION
Only use Groovy Grape's runtime dependencies to load `ArtefactHandler` `ClassInjector` `TraitInjector`, so the Shell no longer need `grace-plugin-controllers` `grace-plugin-gsp` `grace-plugin-url-mappings`, which greatly reduces the size of the final CLI installation package.

- Introduce GrailsArtefactClassTransformation
- Remove some runtime dependencies of grace-shell
- Add support methods in TraitInjectionUtils
- Cleanup ExtendedGroovyClassLoader

See gh-1136
Closes gh-1139