### PR TITLE
Rename `BootStrap.groovy` to `Bootstrap.groovy`

### DIFF
--- a/grace-core/src/test/groovy/org/grails/compiler/injection/ArtefactTypeAstTransformationSpec.groovy
+++ b/grace-core/src/test/groovy/org/grails/compiler/injection/ArtefactTypeAstTransformationSpec.groovy
@@ -188,11 +188,11 @@ class Application {
         when:
         def clazz = gcl.parseClass('''
 @grails.artefact.Artefact("Bootstrap")
-class BootStrap {
+class Bootstrap {
 }
 ''')
 
-        def classNode = gcl.getClassNode('BootStrap')
+        def classNode = gcl.getClassNode('Bootstrap')
 
         then:
         ClassInjector[] bootstrapClassInjectors = classInjectors.findAll { it.shouldInject(classNode) }

--- a/grace-core/src/test/groovy/org/grails/compiler/injection/GlobalGrailsClassInjectorTransformationSpec.groovy
+++ b/grace-core/src/test/groovy/org/grails/compiler/injection/GlobalGrailsClassInjectorTransformationSpec.groovy
@@ -65,11 +65,11 @@ class Application {
 
         when:
         def clazz = gcl.parseClass('''
-class BootStrap {
+class Bootstrap {
 }
-''', '/Users/grails/grails-demo-project/grails-app/init/org/demo/BootStrap.groovy')
+''', '/Users/grails/grails-demo-project/grails-app/init/org/demo/Bootstrap.groovy')
 
-        def classNode = gcl.getClassNode('BootStrap')
+        def classNode = gcl.getClassNode('Bootstrap')
 
         then:
         clazz.getAnnotationsByType(Artefact)

--- a/grace-plugin-controllers/src/main/groovy/org/grails/plugins/web/controllers/ControllersGrailsPlugin.groovy
+++ b/grace-plugin-controllers/src/main/groovy/org/grails/plugins/web/controllers/ControllersGrailsPlugin.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004-2022 the original author or authors.
+ * Copyright 2004-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,7 +26,7 @@ import grails.plugins.Plugin
 import grails.util.GrailsUtil
 
 import org.grails.core.artefact.ControllerArtefactHandler
-import org.grails.plugins.web.servlet.context.BootStrapClassRunner
+import org.grails.plugins.web.servlet.context.BootstrapClassRunner
 
 /**
  * Handles the configuration of controllers for Grails.
@@ -54,9 +54,9 @@ class ControllersGrailsPlugin extends Plugin implements PriorityOrdered {
 
             boolean useJsessionId = config.getProperty(Settings.GRAILS_VIEWS_ENABLE_JSESSIONID, Boolean, false)
 
-            boolean skipBootStrap = Boolean.parseBoolean(System.getProperty(Settings.SETTING_SKIP_BOOTSTRAP))
-            if (!skipBootStrap) {
-                bootStrapClassRunner(BootStrapClassRunner)
+            boolean skipBootstrap = Boolean.parseBoolean(System.getProperty(Settings.SETTING_SKIP_BOOTSTRAP))
+            if (!skipBootstrap) {
+                bootstrapClassRunner(BootstrapClassRunner)
             }
 
             def controllerClasses = application.getArtefacts(ControllerArtefactHandler.TYPE)

--- a/grace-plugin-controllers/src/main/groovy/org/grails/plugins/web/servlet/context/BootstrapClassRunner.groovy
+++ b/grace-plugin-controllers/src/main/groovy/org/grails/plugins/web/servlet/context/BootstrapClassRunner.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2022 the original author or authors.
+ * Copyright 2014-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -36,14 +36,15 @@ import org.grails.web.servlet.boostrap.BootstrapArtefactHandler
 import org.grails.web.servlet.context.GrailsConfigUtils
 
 /**
- * Runs the BootStrap classes on startup
+ * Runs the Bootstrap classes on startup
  *
  * @author Graeme Rocher
+ * @author Michael Yan
  * @since 3.0
  */
 @CompileStatic
 @Commons
-class BootStrapClassRunner extends GrailsApplicationLifeCycleAdapter
+class BootstrapClassRunner extends GrailsApplicationLifeCycleAdapter
         implements GrailsApplicationAware, ServletContextAware, ApplicationContextAware, PluginManagerAware {
 
     GrailsApplication grailsApplication

--- a/grace-test-suite-uber/src/test/groovy/org/grails/commons/BootstrapArtefactHandlerTests.java
+++ b/grace-test-suite-uber/src/test/groovy/org/grails/commons/BootstrapArtefactHandlerTests.java
@@ -25,13 +25,13 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 /**
  * @author Marc Palmer
  */
-public class BootStrapArtefactHandlerTests {
+public class BootstrapArtefactHandlerTests {
 
     @Test
-    public void testIsBootStrapClass() {
+    public void testIsBootstrapClass() {
         GroovyClassLoader gcl = new GroovyClassLoader();
 
-        Class<?> c = gcl.parseClass("@grails.artefact.Artefact('Bootstrap')\nclass TestBootStrap { }\n");
+        Class<?> c = gcl.parseClass("@grails.artefact.Artefact('Bootstrap')\nclass TestBootstrap { }\n");
 
         ArtefactHandler handler = new BootstrapArtefactHandler();
         assertTrue(handler.isArtefact(c));

--- a/grace-web/src/main/groovy/org/grails/web/servlet/boostrap/DefaultGrailsBootstrapClass.java
+++ b/grace-web/src/main/groovy/org/grails/web/servlet/boostrap/DefaultGrailsBootstrapClass.java
@@ -28,7 +28,7 @@ import org.grails.datastore.mapping.reflect.ClassPropertyFetcher;
 
 public class DefaultGrailsBootstrapClass extends AbstractGrailsClass implements GrailsBootstrapClass {
 
-    public static final String BOOT_STRAP = "BootStrap";
+    public static final String BOOT_STRAP = "Bootstrap";
 
     private static final String INIT_CLOSURE = "init";
 

--- a/grace-web/src/test/groovy/org/grails/web/servlet/bootstrap/BootstrapArtefactHandlerSpec.groovy
+++ b/grace-web/src/test/groovy/org/grails/web/servlet/bootstrap/BootstrapArtefactHandlerSpec.groovy
@@ -29,12 +29,12 @@ import org.grails.web.servlet.boostrap.BootstrapArtefactHandler
  */
 class BootstrapArtefactHandlerSpec extends Specification {
 
-    void "Check TestBootStrap within 'grails-app/init'"() {
+    void "Check TestBootstrap within 'grails-app/init'"() {
         given:
         ArtefactHandler handler = new BootstrapArtefactHandler()
         GroovyClassLoader gcl = new GroovyClassLoader()
         Class<?> clazz = gcl.parseClass('''
-class TestBootStrap {
+class TestBootstrap {
 }
 ''')
 
@@ -43,7 +43,7 @@ class TestBootStrap {
         moduleNode.putNodeMetaData('PROJECT_DIR', '/Users/grails/grails-demo-project')
         moduleNode.putNodeMetaData('GRAILS_APP_DIR', '/Users/grails/grails-demo-project/grails-app')
         sourceUnit.getAST() >> moduleNode
-        sourceUnit.getName() >> '/Users/grails/grails-demo-project/grails-app/init/org/grails/demo/TestBootStrap.groovy'
+        sourceUnit.getName() >> '/Users/grails/grails-demo-project/grails-app/init/org/grails/demo/TestBootstrap.groovy'
 
         ClassNode classNode = new ClassNode(clazz)
         classNode.setModule(moduleNode)
@@ -52,12 +52,12 @@ class TestBootStrap {
         handler.isArtefact(classNode)
     }
 
-    void "Check TestBootStrap within 'app/init'"() {
+    void "Check TestBootstrap within 'app/init'"() {
         given:
         ArtefactHandler handler = new BootstrapArtefactHandler()
         GroovyClassLoader gcl = new GroovyClassLoader()
         Class<?> clazz = gcl.parseClass('''
-class TestBootStrap {
+class TestBootstrap {
 }
 ''')
 
@@ -66,7 +66,7 @@ class TestBootStrap {
         moduleNode.putNodeMetaData('PROJECT_DIR', '/Users/grails/grails-demo-project')
         moduleNode.putNodeMetaData('GRAILS_APP_DIR', '/Users/grails/grails-demo-project/app')
         sourceUnit.getAST() >> moduleNode
-        sourceUnit.getName() >> '/Users/grails/grails-demo-project/app/init/org/grails/demo/TestBootStrap.groovy'
+        sourceUnit.getName() >> '/Users/grails/grails-demo-project/app/init/org/grails/demo/TestBootstrap.groovy'
 
         ClassNode classNode = new ClassNode(clazz)
         classNode.setModule(moduleNode)
@@ -75,12 +75,12 @@ class TestBootStrap {
         handler.isArtefact(classNode)
     }
 
-    void "Check TestBootStrap within 'grails-app/boot'"() {
+    void "Check TestBootstrap within 'grails-app/boot'"() {
         given:
         ArtefactHandler handler = new BootstrapArtefactHandler()
         GroovyClassLoader gcl = new GroovyClassLoader()
         Class<?> clazz = gcl.parseClass('''
-class TestBootStrap {
+class TestBootstrap {
 }
 ''')
 
@@ -89,7 +89,7 @@ class TestBootStrap {
         moduleNode.putNodeMetaData('PROJECT_DIR', '/Users/grails/grails-demo-project')
         moduleNode.putNodeMetaData('GRAILS_APP_DIR', '/Users/grails/grails-demo-project/grails-app')
         sourceUnit.getAST() >> moduleNode
-        sourceUnit.getName() >> '/Users/grails/grails-demo-project/grails-app/boot/org/grails/demo/TestBootStrap.groovy'
+        sourceUnit.getName() >> '/Users/grails/grails-demo-project/grails-app/boot/org/grails/demo/TestBootstrap.groovy'
 
         ClassNode classNode = new ClassNode(clazz)
         classNode.setModule(moduleNode)
@@ -121,13 +121,13 @@ class TestBoot {
         !handler.isArtefact(classNode)
     }
 
-    void "Check TestBootStrap within 'grails-app/boot' and annotated with @Artefact('Bootstrap')"() {
+    void "Check TestBootstrap within 'grails-app/boot' and annotated with @Artefact('Bootstrap')"() {
         given:
         ArtefactHandler handler = new BootstrapArtefactHandler()
         GroovyClassLoader gcl = new GroovyClassLoader()
         Class<?> clazz = gcl.parseClass('''
 @grails.artefact.Artefact("Bootstrap")
-class TestBootStrap {
+class TestBootstrap {
 }
 ''')
 
@@ -136,7 +136,7 @@ class TestBootStrap {
         moduleNode.putNodeMetaData('PROJECT_DIR', '/Users/grails/grails-demo-project')
         moduleNode.putNodeMetaData('GRAILS_APP_DIR', '/Users/grails/grails-demo-project/grails-app')
         sourceUnit.getAST() >> moduleNode
-        sourceUnit.getName() >> '/Users/grails/grails-demo-project/grails-app/boot/org/grails/demo/TestBootStrap.groovy'
+        sourceUnit.getName() >> '/Users/grails/grails-demo-project/grails-app/boot/org/grails/demo/TestBootstrap.groovy'
 
         ClassNode classNode = new ClassNode(clazz)
         classNode.setModule(moduleNode)
@@ -145,13 +145,13 @@ class TestBootStrap {
         handler.isArtefact(classNode)
     }
 
-    void "Check TestBootStrap within 'grails-app/init' but now allow abstract"() {
+    void "Check TestBootstrap within 'grails-app/init' but now allow abstract"() {
         given:
         ArtefactHandler handler = new BootstrapArtefactHandler()
         GroovyClassLoader gcl = new GroovyClassLoader()
         Class<?> clazz = gcl.parseClass('''
 @grails.artefact.Artefact("Bootstrap")
-abstract class TestBootStrap {
+abstract class TestBootstrap {
 }
 ''')
 
@@ -160,7 +160,7 @@ abstract class TestBootStrap {
         moduleNode.putNodeMetaData('PROJECT_DIR', '/Users/grails/grails-demo-project')
         moduleNode.putNodeMetaData('GRAILS_APP_DIR', '/Users/grails/grails-demo-project/grails-app')
         sourceUnit.getAST() >> moduleNode
-        sourceUnit.getName() >> '/Users/grails/grails-demo-project/grails-app/init/org/grails/demo/TestBootStrap.groovy'
+        sourceUnit.getName() >> '/Users/grails/grails-demo-project/grails-app/init/org/grails/demo/TestBootstrap.groovy'
 
         ClassNode classNode = new ClassNode(clazz)
         classNode.setModule(moduleNode)
@@ -169,13 +169,13 @@ abstract class TestBootStrap {
         !handler.isArtefact(classNode)
     }
 
-    void "Check TestBootStrap with @Artefact('Bootstrap')"() {
+    void "Check TestBootstrap with @Artefact('Bootstrap')"() {
         given:
         ArtefactHandler handler = new BootstrapArtefactHandler()
         GroovyClassLoader gcl = new GroovyClassLoader()
         Class<?> clazz = gcl.parseClass('''
 @grails.artefact.Artefact("Bootstrap")
-class TestBootStrap {
+class TestBootstrap {
 }
 ''')
         ClassNode classNode = new ClassNode(clazz)
@@ -185,12 +185,12 @@ class TestBootStrap {
         handler.isArtefact(clazz)
     }
 
-    void "Check TestBootStrap without @Artefact('Bootstrap')"() {
+    void "Check TestBootstrap without @Artefact('Bootstrap')"() {
         given:
         ArtefactHandler handler = new BootstrapArtefactHandler()
         GroovyClassLoader gcl = new GroovyClassLoader()
         Class<?> clazz = gcl.parseClass('''
-class TestBootStrap {
+class TestBootstrap {
 }
 ''')
         ClassNode classNode = new ClassNode(clazz)
@@ -200,13 +200,13 @@ class TestBootStrap {
         !handler.isArtefact(clazz)
     }
 
-    void "Check TestBootStrap with @Artefact but wrong type"() {
+    void "Check TestBootstrap with @Artefact but wrong type"() {
         given:
         ArtefactHandler handler = new BootstrapArtefactHandler()
         GroovyClassLoader gcl = new GroovyClassLoader()
         Class<?> clazz = gcl.parseClass('''
 @grails.artefact.Artefact("App")
-class TestBootStrap {
+class TestBootstrap {
 }
 ''')
         ClassNode classNode = new ClassNode(clazz)
@@ -232,13 +232,13 @@ class TestBoot {
         !handler.isArtefact(clazz)
     }
 
-    void "Check TestBootStrap with @Artefact('Bootstrap') but not allow abstract"() {
+    void "Check TestBootstrap with @Artefact('Bootstrap') but not allow abstract"() {
         given:
         ArtefactHandler handler = new BootstrapArtefactHandler()
         GroovyClassLoader gcl = new GroovyClassLoader()
         Class<?> clazz = gcl.parseClass('''
 @grails.artefact.Artefact("Bootstrap")
-abstract class TestBootStrap {
+abstract class TestBootstrap {
 }
 ''')
         ClassNode classNode = new ClassNode(clazz)


### PR DESCRIPTION
- Update `DefaultGrailsBootstrapClass.BOOT_STRAP` to `Bootstrap` as the trailing part of the Bootstrap class type
- Rename `BootStrapClassRunner` to `BootstrapClassRunner`
- Change the bean name to `bootstrapClassRunner` in `ControllersGrailsPlugin`
- Update the other related tests
- We should also update the `base` profile