### PR TITLE
Allow developers to customize the `app` directory

### DIFF
--- a/grace-bootstrap/src/main/groovy/grails/util/BuildSettings.groovy
+++ b/grace-bootstrap/src/main/groovy/grails/util/BuildSettings.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2008-2023 the original author or authors.
+ * Copyright 2008-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,6 +23,7 @@ import groovy.transform.CompileStatic
  * Build time settings and configuration
  *
  * @author Graeme Rocher
+ * @author Michael Yan
  */
 @CompileStatic
 class BuildSettings {
@@ -108,6 +109,11 @@ class BuildSettings {
      * The app directory of the application
      */
     public static final String APP_DIR = 'grails.app.dir'
+
+    /**
+     * The app path of the application
+     */
+    public static final String APP_PATH = 'grails.app.path'
 
     /**
      * The name of the system property for the Grails work directory.
@@ -257,25 +263,51 @@ class BuildSettings {
     }
 
     static {
-        String appBaseDir = System.getProperty(APP_BASE_DIR)
-        if (appBaseDir) {
-            BASE_DIR = new File(appBaseDir)
+        if (System.getProperty(APP_BASE_DIR)) {
+            BASE_DIR = new File(System.getProperty(APP_BASE_DIR))
+        }
+        else if (System.getenv(APP_BASE_DIR)) {
+            BASE_DIR = new File(System.getenv(APP_BASE_DIR))
+        }
+        if (System.getProperty('BASE_DIR')) {
+            BASE_DIR = new File(System.getProperty('BASE_DIR'))
+        }
+        else if (System.getenv('BASE_DIR')) {
+            BASE_DIR = new File(System.getenv('BASE_DIR'))
         }
         else {
             BASE_DIR = new File('.')
         }
 
-        String appDir = System.getProperty(APP_DIR)
-        if (appDir) {
-            GRAILS_APP_DIR = new File(appDir)
+        if (System.getProperty(APP_DIR)) {
+            GRAILS_APP_DIR = new File(System.getProperty(APP_DIR))
+        }
+        else if (System.getenv(APP_DIR)) {
+            GRAILS_APP_DIR = new File(System.getenv(APP_DIR))
+        }
+        else if (System.getProperty('GRAILS_APP_DIR')) {
+            GRAILS_APP_DIR = new File(System.getProperty('GRAILS_APP_DIR'))
+        }
+        else if (System.getenv('GRAILS_APP_DIR')) {
+            GRAILS_APP_DIR = new File(System.getenv('GRAILS_APP_DIR'))
+        }
+        else if (System.getProperty(APP_PATH)) {
+            GRAILS_APP_DIR = new File(BASE_DIR, System.getProperty(APP_PATH))
+        }
+        else if (System.getenv(APP_PATH)) {
+            GRAILS_APP_DIR = new File(BASE_DIR, System.getenv(APP_PATH))
+        }
+        else if (System.getProperty('GRAILS_APP_PATH')) {
+            GRAILS_APP_DIR = new File(BASE_DIR, System.getProperty('GRAILS_APP_PATH'))
+        }
+        else if (System.getenv('GRAILS_APP_PATH')) {
+            GRAILS_APP_DIR = new File(BASE_DIR, System.getenv('GRAILS_APP_PATH'))
+        }
+        else if (new File(BASE_DIR, 'app').exists()) {
+            GRAILS_APP_DIR = new File(BASE_DIR, 'app')
         }
         else {
-            if (new File(BASE_DIR, 'app').exists()) {
-                GRAILS_APP_DIR = new File(BASE_DIR, 'app')
-            }
-            else {
-                GRAILS_APP_DIR = new File(BASE_DIR, 'grails-app')
-            }
+            GRAILS_APP_DIR = new File(BASE_DIR, 'grails-app')
         }
         GRAILS_APP_DIR_PRESENT = GRAILS_APP_DIR?.exists()
         if (GRAILS_APP_DIR_PRESENT) {

--- a/grace-gradle-plugin/src/main/groovy/org/grails/gradle/plugin/core/GrailsExtension.groovy
+++ b/grace-gradle-plugin/src/main/groovy/org/grails/gradle/plugin/core/GrailsExtension.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2023 the original author or authors.
+ * Copyright 2014-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,6 +23,7 @@ import org.gradle.api.Project
  * A extension to the Gradle plugin to configure Grails settings
  *
  * @author Graeme Rocher
+ * @author Michael Yan
  * @since 3.0
  */
 @CompileStatic
@@ -33,6 +34,12 @@ class GrailsExtension {
     GrailsExtension(Project project) {
         this.project = project
     }
+
+    /**
+     * The path of the app directory,
+     * If there is no 'app' in the Gradle project, you can configure it to {@code null}.
+     */
+    String appPath = 'app'
 
     /**
      * Whether to invoke native2ascii on resource bundles

--- a/grace-gradle-plugin/src/main/groovy/org/grails/gradle/plugin/core/GrailsGradlePlugin.groovy
+++ b/grace-gradle-plugin/src/main/groovy/org/grails/gradle/plugin/core/GrailsGradlePlugin.groovy
@@ -35,7 +35,9 @@ import org.gradle.api.file.FileCollection
 import org.gradle.api.java.archives.Manifest
 import org.gradle.api.plugins.ExtraPropertiesExtension
 import org.gradle.api.plugins.GroovyPlugin
+import org.gradle.api.plugins.JavaPluginExtension
 import org.gradle.api.tasks.AbstractCopyTask
+import org.gradle.api.tasks.GroovySourceDirectorySet
 import org.gradle.api.tasks.JavaExec
 import org.gradle.api.tasks.SourceSet
 import org.gradle.api.tasks.SourceSetOutput
@@ -82,7 +84,6 @@ class GrailsGradlePlugin extends GroovyPlugin {
     List<String> excludedGrailsAppSourceDirs = ['assets', 'scripts']
     List<String> grailsAppResourceDirs = ['i18n', 'conf']
     private final ToolingModelBuilderRegistry registry
-    String grailsAppDir
     String grailsVersion
 
     @Inject
@@ -93,7 +94,8 @@ class GrailsGradlePlugin extends GroovyPlugin {
     void apply(Project project) {
         verifyGradleVersion()
 
-        grailsAppDir = SourceSets.resolveGrailsAppDir(project)
+        registerGrailsExtension(project)
+
         grailsVersion = resolveGrailsVersion(project)
 
         // Keep configure system properties First
@@ -111,8 +113,6 @@ class GrailsGradlePlugin extends GroovyPlugin {
         applyDefaultPlugins(project)
 
         registerToolingModelBuilder(project, registry)
-
-        registerGrailsExtension(project)
 
         applyBasePlugins(project)
 
@@ -218,13 +218,16 @@ class GrailsGradlePlugin extends GroovyPlugin {
 
     @CompileStatic
     protected void configureSpringBootExtension(Project project) {
-        project.getTasks().withType(BootRun, {
-            systemProperty(BuildSettings.APP_BASE_DIR, project.projectDir.absolutePath)
-            systemProperty(BuildSettings.APP_DIR, project.file(grailsAppDir).absolutePath)
-            systemProperty(BuildSettings.PROJECT_TARGET_DIR, project.buildDir.absolutePath)
-            systemProperty(BuildSettings.PROJECT_RESOURCES_DIR, new File(project.buildDir, 'resources/main').absolutePath)
-            systemProperty(BuildSettings.PROJECT_CLASSES_DIR, new File(project.buildDir, 'classes/groovy/main').absolutePath)
-        })
+        project.getTasks().withType(BootRun).configureEach { BootRun bootRun ->
+            bootRun.doFirst("Configure System Properties") {
+                String grailsAppPath = SourceSets.resolveGrailsAppPath(project)
+                bootRun.systemProperty(BuildSettings.APP_BASE_DIR, project.projectDir.absolutePath)
+                bootRun.systemProperty(BuildSettings.APP_DIR, grailsAppPath ? project.file(grailsAppPath).absolutePath : '')
+                bootRun.systemProperty(BuildSettings.PROJECT_TARGET_DIR, project.buildDir.absolutePath)
+                bootRun.systemProperty(BuildSettings.PROJECT_RESOURCES_DIR, new File(project.buildDir, 'resources/main').absolutePath)
+                bootRun.systemProperty(BuildSettings.PROJECT_CLASSES_DIR, new File(project.buildDir, 'classes/groovy/main').absolutePath)
+            }
+        }
     }
 
     @CompileStatic
@@ -241,17 +244,20 @@ class GrailsGradlePlugin extends GroovyPlugin {
 
     protected GrailsExtension registerGrailsExtension(Project project) {
         if (project.extensions.findByName('grails') == null) {
-            project.extensions.add('grails', new GrailsExtension(project))
+            project.extensions.create(GrailsExtension, 'grails', GrailsExtension, project)
         }
     }
 
     @CompileStatic
     protected String configureGrailsBuildSettings(Project project) {
-        System.setProperty(BuildSettings.APP_BASE_DIR, project.projectDir.absolutePath)
-        System.setProperty(BuildSettings.APP_DIR, project.file(grailsAppDir).absolutePath)
-        System.setProperty(BuildSettings.PROJECT_TARGET_DIR, project.buildDir.absolutePath)
-        System.setProperty(BuildSettings.PROJECT_RESOURCES_DIR, new File(project.buildDir, 'resources/main').absolutePath)
-        System.setProperty(BuildSettings.PROJECT_CLASSES_DIR, new File(project.buildDir, 'classes/groovy/main').absolutePath)
+        project.afterEvaluate {
+            String grailsAppPath = SourceSets.resolveGrailsAppPath(project)
+            System.setProperty(BuildSettings.APP_BASE_DIR, project.projectDir.absolutePath)
+            System.setProperty(BuildSettings.APP_DIR, grailsAppPath ? project.file(grailsAppPath).absolutePath : '')
+            System.setProperty(BuildSettings.PROJECT_TARGET_DIR, project.buildDir.absolutePath)
+            System.setProperty(BuildSettings.PROJECT_RESOURCES_DIR, new File(project.buildDir, 'resources/main').absolutePath)
+            System.setProperty(BuildSettings.PROJECT_CLASSES_DIR, new File(project.buildDir, 'classes/groovy/main').absolutePath)
+        }
     }
 
     @CompileDynamic
@@ -283,33 +289,31 @@ class GrailsGradlePlugin extends GroovyPlugin {
         }
     }
 
-    @CompileDynamic
+    @CompileStatic
     protected void configureGrailsSourceDirs(Project project) {
-        project.sourceSets {
-            main {
-                groovy {
-                    srcDirs = resolveGrailsSourceDirs(project)
-                }
-                resources {
-                    srcDirs = resolveGrailsResourceDirs(project)
-                }
+        project.afterEvaluate {
+            String grailsAppPath = SourceSets.resolveGrailsAppPath(project)
+            if (grailsAppPath) {
+                SourceSet mainSourceSet = project.getExtensions().getByType(JavaPluginExtension).getSourceSets().getByName(SourceSet.MAIN_SOURCE_SET_NAME)
+                mainSourceSet.getExtensions().getByType(GroovySourceDirectorySet).setSrcDirs(resolveGrailsSourceDirs(project, grailsAppPath))
+                mainSourceSet.getResources().setSrcDirs(resolveGrailsResourceDirs(project, grailsAppPath))
             }
         }
     }
 
     @CompileStatic
-    protected List<File> resolveGrailsResourceDirs(Project project) {
+    protected List<File> resolveGrailsResourceDirs(Project project, String grailsAppPath) {
         List<File> grailsResourceDirs = [project.file('src/main/resources')]
         for (String f in grailsAppResourceDirs) {
-            grailsResourceDirs.add(project.file("${grailsAppDir}/${f}"))
+            grailsResourceDirs.add(project.file("${grailsAppPath}/${f}"))
         }
         grailsResourceDirs
     }
 
     @CompileStatic
-    protected List<File> resolveGrailsSourceDirs(Project project) {
+    protected List<File> resolveGrailsSourceDirs(Project project, String grailsAppPath) {
         List<File> grailsSourceDirs = []
-        project.file(grailsAppDir).eachDir { File subdir ->
+        project.file(grailsAppPath).eachDir { File subdir ->
             if (isGrailsSourceDirectory(subdir)) {
                 grailsSourceDirs.add(subdir)
             }
@@ -409,9 +413,9 @@ class GrailsGradlePlugin extends GroovyPlugin {
     @CompileDynamic
     protected JavaExec createConsoleTask(Project project, TaskContainer tasks, Configuration configuration) {
         tasks.create('console', JavaExec) {
-            systemProperty BuildSettings.APP_BASE_DIR, project.projectDir.absolutePath
             group = 'Grace'
             description = 'Runs the interactive Groovy Console.'
+            systemProperty BuildSettings.APP_BASE_DIR, project.projectDir.absolutePath
             systemProperty 'spring.devtools.restart.enabled', false
             systemProperty 'spring.output.ansi.enabled', 'always'
             classpath = project.sourceSets.main.runtimeClasspath + configuration
@@ -422,9 +426,9 @@ class GrailsGradlePlugin extends GroovyPlugin {
     @CompileDynamic
     protected JavaExec createShellTask(Project project, TaskContainer tasks, Configuration configuration) {
         tasks.create('shell', JavaExec) {
-            systemProperty BuildSettings.APP_BASE_DIR, project.projectDir.absolutePath
             group = 'Grace'
             description = 'Runs the interactive Groovy Shell.'
+            systemProperty BuildSettings.APP_BASE_DIR, project.projectDir.absolutePath
             systemProperty 'spring.devtools.restart.enabled', false
             systemProperty 'spring.output.ansi.enabled', 'always'
             classpath = project.sourceSets.main.runtimeClasspath + configuration
@@ -453,17 +457,17 @@ class GrailsGradlePlugin extends GroovyPlugin {
     @CompileDynamic
     protected void enableNative2Ascii(Project project, String grailsVersion) {
         project.afterEvaluate {
-            SourceSet sourceSet = SourceSets.findMainSourceSet(project)
-
+            String grailsAppPath = SourceSets.resolveGrailsAppPath(project)
             TaskContainer taskContainer = project.tasks
 
+            SourceSet sourceSet = SourceSets.findMainSourceSet(project)
             taskContainer.getByName(sourceSet.processResourcesTaskName) { AbstractCopyTask task ->
                 GrailsExtension grailsExt = project.extensions.getByType(GrailsExtension)
                 boolean native2ascii = grailsExt.isNative2ascii()
                 task.setDuplicatesStrategy(DuplicatesStrategy.INCLUDE)
                 if (native2ascii && grailsExt.isNative2asciiAnt() && !taskContainer.findByName('native2ascii')) {
                     File destinationDir = ((ProcessResources) task).destinationDir
-                    Task native2asciiTask = createNative2AsciiTask(taskContainer, project.file("${grailsAppDir}/i18n"), destinationDir)
+                    Task native2asciiTask = createNative2AsciiTask(taskContainer, project.file("${grailsAppPath}/i18n"), destinationDir)
                     task.dependsOn(native2asciiTask)
                 }
 
@@ -665,14 +669,16 @@ class GrailsGradlePlugin extends GroovyPlugin {
         def projectVersion = project.version
         def projectDir = project.projectDir.absolutePath
         def projectType = getGrailsProjectType()
-        def grailsAppDir = new File(project.projectDir, grailsAppDir).absolutePath
-        if (System.getProperty('os.name').startsWith('Windows')) {
-            projectDir = projectDir.replace('\\', '\\\\')
-            grailsAppDir = grailsAppDir.replace('\\', '\\\\')
-        }
+
         configScriptTask.inputs.property('name', projectName)
         configScriptTask.inputs.property('version', projectVersion)
         configScriptTask.doLast {
+            String grailsAppPath = SourceSets.resolveGrailsAppPath(project)
+            String grailsAppDir = grailsAppPath ? project.file(grailsAppPath).absolutePath : ''
+            if (System.getProperty('os.name').startsWith('Windows')) {
+                projectDir = projectDir.replace('\\', '\\\\')
+                grailsAppDir = grailsAppDir.replace('\\', '\\\\')
+            }
             configFile.parentFile.mkdirs()
             configFile.text = """
 withConfig(configuration) {

--- a/grace-gradle-plugin/src/main/groovy/org/grails/gradle/plugin/core/GrailsPluginGradlePlugin.groovy
+++ b/grace-gradle-plugin/src/main/groovy/org/grails/gradle/plugin/core/GrailsPluginGradlePlugin.groovy
@@ -90,10 +90,15 @@ class GrailsPluginGradlePlugin extends GrailsGradlePlugin {
     }
 
     protected void checkForConfigurationClash(Project project) {
-        File yamlConfig = new File(project.projectDir, "${grailsAppDir}/conf/plugin.yml")
-        File groovyConfig = new File(project.projectDir, "${grailsAppDir}/conf/plugin.groovy")
-        if (yamlConfig.exists() && groovyConfig.exists()) {
-            throw new RuntimeException('A plugin may define a plugin.yml or a plugin.groovy, but not both')
+        project.afterEvaluate {
+            String grailsAppPath = SourceSets.resolveGrailsAppPath(project)
+            if (grailsAppPath) {
+                File yamlConfig = new File(project.projectDir, "${grailsAppPath}/conf/plugin.yml")
+                File groovyConfig = new File(project.projectDir, "${grailsAppPath}/conf/plugin.groovy")
+                if (yamlConfig.exists() && groovyConfig.exists()) {
+                    throw new RuntimeException('A plugin may define a plugin.yml or a plugin.groovy, but not both')
+                }
+            }
         }
     }
 

--- a/grace-gradle-plugin/src/main/groovy/org/grails/gradle/plugin/core/IntegrationTestGradlePlugin.groovy
+++ b/grace-gradle-plugin/src/main/groovy/org/grails/gradle/plugin/core/IntegrationTestGradlePlugin.groovy
@@ -21,10 +21,10 @@ import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.artifacts.ConfigurationContainer
 import org.gradle.api.artifacts.dsl.DependencyHandler
-import org.gradle.api.file.FileCollection
 import org.gradle.api.tasks.SourceSet
 import org.gradle.api.tasks.SourceSetContainer
 import org.gradle.api.tasks.TaskContainer
+import org.gradle.api.tasks.TaskProvider
 import org.gradle.api.tasks.testing.Test
 import org.gradle.api.tasks.testing.TestReport
 import org.gradle.language.base.plugins.LifecycleBasePlugin
@@ -35,7 +35,12 @@ import org.grails.gradle.plugin.util.SourceSets
  * Gradle plugin for adding separate src/integration-test folder to hold integration tests
  *
  * Adds integrationTestImplementation and integrationTestRuntimeOnly configurations
- * that extend from testCompileClasspath and testRuntimeClasspath
+ * that extend from testCompileClasspath and testRuntimeClasspath.
+ *
+ * @author Lari Hotari
+ * @author Graeme Rocher
+ * @author Michael Yan
+ * @since 3.0
  */
 @CompileStatic
 class IntegrationTestGradlePlugin implements Plugin<Project> {
@@ -45,7 +50,10 @@ class IntegrationTestGradlePlugin implements Plugin<Project> {
 
     @Override
     void apply(Project project) {
-        File[] sourceDirs = findIntegrationTestSources(project)
+        File[] sourceDirs = project.file(sourceFolderName).listFiles({ File file ->
+            file.isDirectory() && !file.name.contains('.')
+        } as FileFilter)
+
         if (sourceDirs) {
             List<File> acceptedSourceDirs = []
             SourceSetContainer sourceSets = SourceSets.findSourceSets(project)
@@ -56,10 +64,6 @@ class IntegrationTestGradlePlugin implements Plugin<Project> {
                 acceptedSourceDirs.add srcDir
             }
 
-            String grailsAppDir = SourceSets.resolveGrailsAppDir(project)
-            File resources = new File(project.projectDir, "${grailsAppDir}/conf")
-            integrationTestSources.resources.srcDir(resources)
-
             DependencyHandler dependencies = project.dependencies
             dependencies.add('integrationTestImplementation', SourceSets.findMainSourceSet(project).output)
             dependencies.add('integrationTestImplementation', SourceSets.findSourceSet(project, SourceSet.TEST_SOURCE_SET_NAME).output)
@@ -68,18 +72,10 @@ class IntegrationTestGradlePlugin implements Plugin<Project> {
             configurations.getByName('integrationTestRuntimeOnly').extendsFrom(configurations.getByName('testRuntimeClasspath'))
 
             TaskContainer tasks = project.tasks
-            tasks.register('integrationTest', Test) { Test integrationTestTask ->
-                integrationTestTask.group = LifecycleBasePlugin.VERIFICATION_GROUP
-                setClassesDirs(integrationTestTask, integrationTestSources)
-                integrationTestTask.classpath = integrationTestSources.runtimeClasspath
-                integrationTestTask.maxParallelForks = 1
-                integrationTestTask.reports.html.required.set(false)
-                integrationTestTask.shouldRunAfter('test')
-                tasks.findByName('check')?.dependsOn(integrationTestTask)
-            }
+            TaskProvider<Test> testTask = tasks.named('test', Test)
 
-            tasks.register('mergeTestReports', TestReport) { TestReport testReportTask ->
-                testReportTask.dependsOn('test')
+            TaskProvider<TestReport> mergeTestReports = tasks.register('mergeTestReports', TestReport) { TestReport testReportTask ->
+                testReportTask.dependsOn(testTask)
 
                 testReportTask.getDestinationDirectory().set(project.layout.buildDirectory.dir('reports/tests'))
                 testReportTask.getTestResults().from(project.layout.buildDirectory.dir('test-results/binary/test'),
@@ -87,19 +83,34 @@ class IntegrationTestGradlePlugin implements Plugin<Project> {
                         // different versions of Gradle store these results in different places. ugh.
                         project.layout.buildDirectory.dir('test-results/test/binary'),
                         project.layout.buildDirectory.dir('test-results/integrationTest/binary'))
-
-                tasks.findByName('integrationTestTask')?.finalizedBy testReportTask
             }
+
+            TaskProvider<Test> integrationTestTask = tasks.register('integrationTest', Test, { Test integrationTest ->
+                integrationTest.group = LifecycleBasePlugin.VERIFICATION_GROUP
+                integrationTest.description = 'Runs the integration tests.'
+                integrationTest.setTestClassesDirs(integrationTestSources.output.classesDirs)
+                integrationTest.classpath = integrationTestSources.runtimeClasspath
+                integrationTest.maxParallelForks = 1
+                integrationTest.reports.html.required.set(false)
+            })
+            integrationTestTask.configure { Test integrationTest ->
+                integrationTest.shouldRunAfter(testTask)
+                integrationTest.finalizedBy(mergeTestReports)
+                integrationTest.doFirst {
+                    String grailsAppPath = SourceSets.resolveGrailsAppPath(project)
+                    if (grailsAppPath) {
+                        File resources = project.file("${grailsAppPath}/conf")
+                        integrationTestSources.resources.srcDir(resources)
+                    }
+                }
+            }
+            tasks.named(LifecycleBasePlugin.CHECK_TASK_NAME)
+                    .configure((check) -> check.dependsOn(integrationTestTask))
 
             if (ideaIntegration) {
                 integrateIdea(project, acceptedSourceDirs)
             }
         }
-    }
-
-    protected void setClassesDirs(Test integrationTestTask, SourceSet sourceSet) {
-        FileCollection classesDirs = sourceSet.output.classesDirs
-        integrationTestTask.setTestClassesDirs(classesDirs)
     }
 
     @CompileDynamic
@@ -121,10 +132,6 @@ class IntegrationTestGradlePlugin implements Plugin<Project> {
                 }
             }
         }
-    }
-
-    File[] findIntegrationTestSources(Project project) {
-        project.file(sourceFolderName).listFiles({ File file -> file.isDirectory() && !file.name.contains('.') } as FileFilter)
     }
 
 }

--- a/grace-gradle-plugin/src/main/groovy/org/grails/gradle/plugin/util/BuildSettings.groovy
+++ b/grace-gradle-plugin/src/main/groovy/org/grails/gradle/plugin/util/BuildSettings.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2023 the original author or authors.
+ * Copyright 2022-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -39,13 +39,18 @@ class BuildSettings {
     public static final String APP_DIR = 'grails.app.dir'
 
     /**
+     * The app path of the application
+     */
+    public static final String APP_PATH = 'grails.app.path'
+
+    /**
      * The name of the system property for the the project target directory.
      * Must be set if Gradle build location is changed.
      */
     public static final String PROJECT_TARGET_DIR = 'grails.project.target.dir'
 
     /**
-     * The name of the system property for {@link #}.
+     * The name of the system property for the project resources directory.
      */
     public static final String PROJECT_RESOURCES_DIR = 'grails.project.resource.dir'
 
@@ -53,5 +58,15 @@ class BuildSettings {
      * The name of the system property for the project classes directory.
      */
     public static final String PROJECT_CLASSES_DIR = 'grails.project.class.dir'
+
+    /**
+     * The default app path of Grails.
+     */
+    public static final String DEFAULT_GRAILS_APP_PATH = 'grails-app'
+
+    /**
+     * The default app path of Grace.
+     */
+    public static final String DEFAULT_GRACE_APP_PATH = 'app'
 
 }

--- a/grace-gradle-plugin/src/main/groovy/org/grails/gradle/plugin/util/SourceSets.groovy
+++ b/grace-gradle-plugin/src/main/groovy/org/grails/gradle/plugin/util/SourceSets.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2024 the original author or authors.
+ * Copyright 2014-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,8 +22,16 @@ import org.gradle.api.plugins.JavaPluginExtension
 import org.gradle.api.tasks.SourceSet
 import org.gradle.api.tasks.SourceSetContainer
 
+import org.grails.gradle.plugin.core.GrailsExtension
+
+import static org.grails.gradle.plugin.util.BuildSettings.APP_DIR
+import static org.grails.gradle.plugin.util.BuildSettings.APP_PATH
+import static org.grails.gradle.plugin.util.BuildSettings.DEFAULT_GRACE_APP_PATH
+import static org.grails.gradle.plugin.util.BuildSettings.DEFAULT_GRAILS_APP_PATH
+
 /**
  * @author Graeme Rocher
+ * @author Michael Yan
  * @since 3.0
  */
 @CompileStatic
@@ -56,13 +64,79 @@ class SourceSets {
         sourceSets
     }
 
+    /**
+     * Resolve the directory of Grails app, for examples, 'grails-app', 'app'.
+     *
+     * @param project the Gradle project
+     * @return the directory of Grails application
+     * @deprecated since 2024.0.0, in favor of {@link #resolveGrailsAppPath(Project)}
+     */
+    @Deprecated(since = '2024.0.0', forRemoval = true)
     static String resolveGrailsAppDir(Project project) {
-        List<String> grailsAppDirs = ['grails-app', 'app']
+        List<String> grailsAppDirs = [DEFAULT_GRAILS_APP_PATH, DEFAULT_GRACE_APP_PATH]
         String grailsAppDir = grailsAppDirs.find { String dir -> project.file(dir).exists() }
         if (!grailsAppDir) {
-            throw new GradleException("Grails requires an application directory : 'grails-app' or 'app'.")
+            throw new GradleException("Grace requires an application directory : 'grails-app' or 'app'.")
         }
         grailsAppDir
+    }
+
+    /**
+     * Resolve the directory of Grails app, for examples, 'grails-app', 'app', but you can always configure it.
+     *
+     * @param project the Gradle project
+     * @return the directory of Grails application
+     * @since 2024.0.0
+     */
+    static String resolveGrailsAppPath(Project project) {
+        File baseDir = project.projectDir
+        File appDir = null
+
+        if (System.getProperty(APP_DIR)) {
+            appDir = new File(System.getProperty(APP_DIR))
+        }
+        else if (System.getenv(APP_DIR)) {
+            appDir = new File(System.getenv(APP_DIR))
+        }
+        else if (System.getProperty('GRAILS_APP_DIR')) {
+            appDir = new File(System.getProperty('GRAILS_APP_DIR'))
+        }
+        else if (System.getenv('GRAILS_APP_DIR')) {
+            appDir = new File(System.getenv('GRAILS_APP_DIR'))
+        }
+        else if (System.getProperty(APP_PATH)) {
+            appDir = new File(baseDir, System.getProperty(APP_PATH))
+        }
+        else if (System.getenv(APP_PATH)) {
+            appDir = new File(baseDir, System.getenv(APP_PATH))
+        }
+        else if (System.getProperty('GRAILS_APP_PATH')) {
+            appDir = new File(baseDir, System.getProperty('GRAILS_APP_PATH'))
+        }
+        else if (System.getenv('GRAILS_APP_PATH')) {
+            appDir = new File(baseDir, System.getenv('GRAILS_APP_PATH'))
+        }
+        if (appDir?.exists()) {
+            return appDir.absolutePath.substring(baseDir.absolutePath.length() + 1)
+        }
+        String appPath = project.getExtensions().getByType(GrailsExtension).appPath?.trim()
+        if (!appPath) {
+            return ''
+        }
+        else {
+            appDir = new File(baseDir, appPath)
+        }
+
+        if (appDir.exists()) {
+            return appPath
+        }
+        else if (appPath != DEFAULT_GRACE_APP_PATH && System.getProperty('grails.gradle.app-path.checked') != 'true') {
+            System.setProperty('grails.gradle.app-path.checked', 'true')
+            throw new GradleException("Grace requires an application directory : [$appDir] not exist, please check it again!")
+        }
+        else {
+            return ''
+        }
     }
 
 }

--- a/grace-gradle-plugin/src/main/groovy/org/grails/gradle/plugin/web/gsp/GroovyPagePlugin.groovy
+++ b/grace-gradle-plugin/src/main/groovy/org/grails/gradle/plugin/web/gsp/GroovyPagePlugin.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2024 the original author or authors.
+ * Copyright 2014-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,6 +24,8 @@ import org.gradle.api.artifacts.Configuration
 import org.gradle.api.file.FileCollection
 import org.gradle.api.tasks.SourceSet
 import org.gradle.api.tasks.SourceSetOutput
+import org.gradle.api.tasks.TaskContainer
+import org.gradle.api.tasks.TaskProvider
 import org.gradle.api.tasks.bundling.Jar
 import org.gradle.api.tasks.bundling.War
 
@@ -34,6 +36,7 @@ import org.grails.gradle.plugin.util.SourceSets
  * A plugin that adds support for compiling Groovy Server Pages (GSP)
  *
  * @author Graeme Rocher
+ * @author Michael Yan
  * @since 3.0
  */
 @CompileStatic
@@ -59,49 +62,48 @@ class GroovyPagePlugin implements Plugin<Project> {
             allClasspath += providedConfig
         }
 
-        String grailsAppDir = SourceSets.resolveGrailsAppDir(project)
+        TaskContainer tasks = project.tasks
 
-        def allTasks = project.tasks
-
-        def compileGroovyPages = allTasks.create('compileGroovyPages', GroovyPageForkCompileTask) {
-            group = 'grace'
-            description = 'Compiles the Groovy server pages (GSP).'
-            destinationDirectory.set(destDir)
-            tmpDirPath = getTmpDirPath(project)
-            source = project.file("${project.projectDir}/${grailsAppDir}/views")
-            serverpath = '/WEB-INF/grails-app/views/'
+        TaskProvider<GroovyPageForkCompileTask> compileWebappGroovyPages = tasks.register(
+                'compileWebappGroovyPages', GroovyPageForkCompileTask) { GroovyPageForkCompileTask task ->
+            task.group = 'grace'
+            task.description = "Compiles the Groovy server pages (GSP) in 'src/main/webapp'."
+            task.destinationDirectory.set(destDir)
+            task.source = project.file("src/main/webapp")
+            task.tmpDirPath = getTmpDirPath(project)
+            task.serverpath = '/'
+            task.classpath = allClasspath
         }
 
-        compileGroovyPages.setClasspath(allClasspath)
-
-        def compileWebappGroovyPages = allTasks.create('compileWebappGroovyPages', GroovyPageForkCompileTask) {
-            group = 'grace'
-            description = "Compiles the Groovy server pages (GSP) in 'src/main/webapp'."
-            destinationDirectory.set(destDir)
-            source = project.file("${project.projectDir}/src/main/webapp")
-            tmpDirPath = getTmpDirPath(project)
-            serverpath = '/'
+        TaskProvider<GroovyPageForkCompileTask> compileGroovyPages = tasks.register(
+                'compileGroovyPages', GroovyPageForkCompileTask) { GroovyPageForkCompileTask task ->
+            task.group = 'grace'
+            task.description = 'Compiles the Groovy server pages (GSP).'
+            task.destinationDirectory.set(destDir)
+            task.tmpDirPath = getTmpDirPath(project)
+            task.classpath = allClasspath
+            task.dependsOn(tasks.named('classes'))
+            task.dependsOn(compileWebappGroovyPages)
         }
 
-        compileWebappGroovyPages.setClasspath(allClasspath)
-
-        project.afterEvaluate {
+        tasks.withType(GroovyPageForkCompileTask).configureEach { GroovyPageForkCompileTask task ->
             GrailsExtension grailsExt = project.extensions.getByType(GrailsExtension)
+            String grailsAppPath = SourceSets.resolveGrailsAppPath(project)
+            if (grailsAppPath) {
+                task.source = project.file("${grailsAppPath}/views")
+                task.serverpath = '/WEB-INF/grails-app/views/'
+            }
+
             if (grailsExt.getPathingJar() && Os.isFamily(Os.FAMILY_WINDOWS)) {
-                Jar pathingJar = (Jar) allTasks.findByName('pathingJar')
+                Jar pathingJar = (Jar) tasks.findByName('pathingJar')
                 allClasspath = project.files("${project.buildDir}/classes/groovy/main",
                         "${project.buildDir}/resources/main", pathingJar.archiveFile.get().getAsFile())
-                compileGroovyPages.dependsOn(pathingJar)
-                compileGroovyPages.setClasspath(allClasspath)
-                compileWebappGroovyPages.dependsOn(pathingJar)
-                compileWebappGroovyPages.setClasspath(allClasspath)
+                task.dependsOn(pathingJar)
+                task.setClasspath(allClasspath)
             }
         }
 
-        compileGroovyPages.dependsOn(allTasks.findByName('classes'))
-        compileGroovyPages.dependsOn(compileWebappGroovyPages)
-
-        allTasks.withType(War) { War war ->
+        tasks.withType(War) { War war ->
             war.dependsOn compileGroovyPages
             if (war.classpath) {
                 war.classpath = war.classpath + project.files(destDir)
@@ -110,7 +112,7 @@ class GroovyPagePlugin implements Plugin<Project> {
                 war.classpath = project.files(destDir)
             }
         }
-        allTasks.withType(Jar) { Jar jar ->
+        tasks.withType(Jar) { Jar jar ->
             if (!(jar instanceof War)) {
                 if (jar.name == 'bootJar') {
                     jar.dependsOn compileGroovyPages


### PR DESCRIPTION
Grails employs a structured directory layout that organizes files and folders based on their functionality, which is essential for maintaining code in a large application. The `app` directory is central to a Grails application, containing subdirectories for domains, services, views, controllers, taglibs and assets, which follow the MVC architectural pattern. In the past, Grails has always adhered to the convention of using `grails-app` as a fixed directory since its inception. In Grace, we can use `grails-app`, or the more concise `app`. Now, in the upcoming Grace 2024 version, we take it a step further by allowing developers to customize this directory. You are free to choose a more suitable specific directory, such as `web`, `admin`, `api`, or `store`.