### PR TITLE
Refactor Gradle plugins

### DIFF
--- a/grace-gradle-plugin/src/main/groovy/org/grails/gradle/plugin/commands/ApplicationContextCommandTask.groovy
+++ b/grace-gradle-plugin/src/main/groovy/org/grails/gradle/plugin/commands/ApplicationContextCommandTask.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2023 the original author or authors.
+ * Copyright 2014-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,9 +19,11 @@ import groovy.transform.CompileStatic
 import org.gradle.api.tasks.JavaExec
 
 /**
- *
+ * The task to run {@link grails.dev.commands.ApplicationCommand}
  *
  * @author Graeme Rocher
+ * @author Michael Yan
+ *
  * @since 3.0
  */
 @CompileStatic
@@ -29,7 +31,6 @@ class ApplicationContextCommandTask extends JavaExec {
 
     ApplicationContextCommandTask() {
         getMainClass().set('grails.ui.command.GrailsApplicationCommandRunner')
-        dependsOn('classes', 'findMainClass')
         systemProperties(System.properties.findAll { it.key.toString().startsWith('grails.') } as Map<String, Object>)
     }
 

--- a/grace-gradle-plugin/src/main/groovy/org/grails/gradle/plugin/commands/ApplicationContextScriptTask.groovy
+++ b/grace-gradle-plugin/src/main/groovy/org/grails/gradle/plugin/commands/ApplicationContextScriptTask.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2022 the original author or authors.
+ * Copyright 2014-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,12 +18,19 @@ package org.grails.gradle.plugin.commands
 import groovy.transform.CompileStatic
 import org.gradle.api.tasks.JavaExec
 
+/**
+ * The task to run Groovy scripts
+ *
+ * @author Graeme Rocher
+ * @author Michael Yan
+ *
+ * @since 3.0
+ */
 @CompileStatic
 class ApplicationContextScriptTask extends JavaExec {
 
     ApplicationContextScriptTask() {
         getMainClass().set('grails.ui.script.GrailsApplicationScriptRunner')
-        dependsOn('classes', 'findMainClass')
         systemProperties(System.properties.findAll { it.key.toString().startsWith('grails.') } as Map<String, Object>)
     }
 

--- a/grace-gradle-plugin/src/main/groovy/org/grails/gradle/plugin/core/GrailsGradlePlugin.groovy
+++ b/grace-gradle-plugin/src/main/groovy/org/grails/gradle/plugin/core/GrailsGradlePlugin.groovy
@@ -79,8 +79,11 @@ import org.grails.gradle.plugin.util.SourceSets
 @CompileStatic
 class GrailsGradlePlugin extends GroovyPlugin {
 
-    public static final String CONSOLE_CONFIGURATION = 'console'
-    public static final String PROFILE_CONFIGURATION = 'profile'
+    public static final String GRAILS_EXTENSION_NAME = 'grails'
+    public static final String CONSOLE_CONFIGURATION_NAME = 'console'
+    public static final String PROFILE_CONFIGURATION_NAME = 'profile'
+    public static final String FIND_MAIN_CLASS_TASK_NAME = 'findMainClass'
+    public static final String BUILD_PROPERTIES_TASK_NAME = 'buildProperties'
 
     List<Class<Plugin>> basePluginClasses = [IntegrationTestGradlePlugin] as List<Class<Plugin>>
     List<String> excludedGrailsAppSourceDirs = ['assets', 'scripts']
@@ -134,11 +137,12 @@ class GrailsGradlePlugin extends GroovyPlugin {
     }
 
     protected void configureProfile(Project project) {
-        if (project.configurations.findByName(PROFILE_CONFIGURATION) == null) {
-            Configuration profileConfiguration = project.configurations.create(PROFILE_CONFIGURATION)
+        if (project.configurations.findByName(PROFILE_CONFIGURATION_NAME) == null) {
+            Configuration profileConfiguration = project.configurations.create(PROFILE_CONFIGURATION_NAME)
             profileConfiguration.incoming.beforeResolve {
                 if (!profileConfiguration.allDependencies) {
-                    addDefaultProfile(project, profileConfiguration)
+                    String profileDependency = "org.graceframework.profiles:${System.getProperty('grails.profile') ?: defaultProfile}:"
+                    project.dependencies.add(PROFILE_CONFIGURATION_NAME, profileDependency)
                 }
             }
         }
@@ -180,13 +184,9 @@ class GrailsGradlePlugin extends GroovyPlugin {
         'web'
     }
 
-    void addDefaultProfile(Project project, Configuration profileConfig) {
-        project.dependencies.add(PROFILE_CONFIGURATION, "org.graceframework.profiles:${System.getProperty('grails.profile') ?: defaultProfile}:")
-    }
-
     @CompileDynamic
     protected void createBuildPropertiesTask(Project project) {
-        if (project.tasks.findByName('buildProperties') == null) {
+        if (project.tasks.findByName(BUILD_PROPERTIES_TASK_NAME) == null) {
             File resourcesDir = SourceSets.findMainSourceSet(project).output.resourcesDir
             File buildInfoFile = new File(resourcesDir, 'META-INF/grails.build.info')
 
@@ -196,7 +196,7 @@ class GrailsGradlePlugin extends GroovyPlugin {
                     'info.app.version': project.version instanceof Serializable ? project.version : project.version.toString(),
                     'info.app.grailsVersion': grailsVersion]
 
-            TaskProvider<Task> buildPropertiesTask = project.tasks.register('buildProperties') { Task task ->
+            TaskProvider<Task> buildPropertiesTask = project.tasks.register(BUILD_PROPERTIES_TASK_NAME) { Task task ->
                 task.group = 'build'
                 task.description = "Build properties into 'META-INF/grails.build.info'."
                 task.inputs.properties(buildPropertiesContents)
@@ -242,8 +242,8 @@ class GrailsGradlePlugin extends GroovyPlugin {
     }
 
     protected GrailsExtension registerGrailsExtension(Project project) {
-        if (project.extensions.findByName('grails') == null) {
-            project.extensions.create(GrailsExtension, 'grails', GrailsExtension, project)
+        if (project.extensions.findByName(GRAILS_EXTENSION_NAME) == null) {
+            project.extensions.create(GrailsExtension, GRAILS_EXTENSION_NAME, GrailsExtension, project)
         }
     }
 
@@ -260,9 +260,9 @@ class GrailsGradlePlugin extends GroovyPlugin {
     }
 
     protected void configureApplicationCommands(Project project) {
-        Configuration runtimeClasspath = project.getConfigurations().getByName(JavaPlugin.RUNTIME_CLASSPATH_CONFIGURATION_NAME)
-        Configuration consoleClasspath = project.configurations.getByName(CONSOLE_CONFIGURATION)
-        Configuration profileClasspath = project.configurations.getByName(PROFILE_CONFIGURATION)
+        Configuration runtimeClasspath = project.configurations.getByName(JavaPlugin.RUNTIME_CLASSPATH_CONFIGURATION_NAME)
+        Configuration consoleClasspath = project.configurations.getByName(CONSOLE_CONFIGURATION_NAME)
+        Configuration profileClasspath = project.configurations.getByName(PROFILE_CONFIGURATION_NAME)
 
         URL[] urls = [project.layout.buildDirectory.dir('classes/groovy/main').get().asFile.toURI().toURL()]
         ClassLoader classLoader = new URLClassLoader(urls, GrailsFactoriesLoader.classLoader)
@@ -293,8 +293,8 @@ class GrailsGradlePlugin extends GroovyPlugin {
         project.afterEvaluate {
             String grailsAppPath = SourceSets.resolveGrailsAppPath(project)
             if (grailsAppPath) {
-                SourceSet mainSourceSet = project.getExtensions().getByType(JavaPluginExtension).getSourceSets().getByName(SourceSet.MAIN_SOURCE_SET_NAME)
-                mainSourceSet.getExtensions().getByType(GroovySourceDirectorySet).setSrcDirs(resolveGrailsSourceDirs(project, grailsAppPath))
+                SourceSet mainSourceSet = project.extensions.getByType(JavaPluginExtension).getSourceSets().getByName(SourceSet.MAIN_SOURCE_SET_NAME)
+                mainSourceSet.extensions.getByType(GroovySourceDirectorySet).setSrcDirs(resolveGrailsSourceDirs(project, grailsAppPath))
                 mainSourceSet.getResources().setSrcDirs(resolveGrailsResourceDirs(project, grailsAppPath))
             }
         }
@@ -380,11 +380,11 @@ class GrailsGradlePlugin extends GroovyPlugin {
     }
 
     protected void configureConsoleTask(Project project) {
-        Configuration runtimeClasspath = project.getConfigurations().getByName(JavaPlugin.RUNTIME_CLASSPATH_CONFIGURATION_NAME)
+        Configuration runtimeClasspath = project.configurations.getByName(JavaPlugin.RUNTIME_CLASSPATH_CONFIGURATION_NAME)
         TaskContainer tasks = project.tasks
 
-        if (project.configurations.findByName('console') == null) {
-            Configuration consoleConfiguration = project.configurations.create(CONSOLE_CONFIGURATION)
+        if (project.configurations.findByName(CONSOLE_CONFIGURATION_NAME) == null) {
+            Configuration consoleConfiguration = project.configurations.create(CONSOLE_CONFIGURATION_NAME)
 
             TaskProvider<JavaExec> consoleTask = tasks.register('console', JavaExec) { JavaExec console ->
                 console.group = 'Grace'
@@ -408,15 +408,15 @@ class GrailsGradlePlugin extends GroovyPlugin {
             }
 
             consoleTask.configure {
-                it.dependsOn(tasks.named('classes'), tasks.withType(FindMainClassTask))
+                it.dependsOn(tasks.named(JavaPlugin.CLASSES_TASK_NAME), tasks.withType(FindMainClassTask))
             }
             shellTask.configure {
-                it.dependsOn(tasks.named('classes'), tasks.withType(FindMainClassTask))
+                it.dependsOn(tasks.named(JavaPlugin.CLASSES_TASK_NAME), tasks.withType(FindMainClassTask))
             }
 
             tasks.withType(FindMainClassTask).configureEach {
                 it.doLast {
-                    ExtraPropertiesExtension extraProperties = (ExtraPropertiesExtension) project.getExtensions().getByName('ext')
+                    ExtraPropertiesExtension extraProperties = (ExtraPropertiesExtension) project.extensions.getByName('ext')
                     def mainClassName = extraProperties.get('mainClassName')
                     if (mainClassName) {
                         consoleTask.configure {
@@ -432,19 +432,19 @@ class GrailsGradlePlugin extends GroovyPlugin {
     }
 
     protected void registerFindMainClassTask(Project project) {
-        Task findMainClassTask = project.tasks.findByName('findMainClass')
+        Task findMainClassTask = project.tasks.findByName(FIND_MAIN_CLASS_TASK_NAME)
         if (findMainClassTask == null) {
-            project.tasks.register('findMainClass', FindMainClassTask) { FindMainClassTask task ->
+            project.tasks.register(FIND_MAIN_CLASS_TASK_NAME, FindMainClassTask) { FindMainClassTask task ->
                 task.group = 'build'
                 task.description = 'Finds the main class of the application.'
-                task.dependsOn(project.tasks.named('classes'))
+                task.dependsOn(project.tasks.named(JavaPlugin.CLASSES_TASK_NAME))
             }
         }
         else if (!FindMainClassTask.isAssignableFrom(findMainClassTask.class)) {
             project.tasks.register('grailsFindMainClass', FindMainClassTask) { FindMainClassTask task ->
                 task.group = 'build'
                 task.description = 'Finds the main class of the application.'
-                task.dependsOn(project.tasks.named('classes'), findMainClassTask)
+                task.dependsOn(project.tasks.named(JavaPlugin.CLASSES_TASK_NAME), findMainClassTask)
                 findMainClassTask.finalizedBy(task)
             }
         }
@@ -517,9 +517,9 @@ class GrailsGradlePlugin extends GroovyPlugin {
     }
 
     protected void configureRunScript(Project project) {
-        Configuration runtimeClasspath = project.getConfigurations().getByName(JavaPlugin.RUNTIME_CLASSPATH_CONFIGURATION_NAME)
-        Configuration consoleClasspath = project.configurations.getByName(CONSOLE_CONFIGURATION)
-        Configuration profileClasspath = project.configurations.getByName(PROFILE_CONFIGURATION)
+        Configuration runtimeClasspath = project.configurations.getByName(JavaPlugin.RUNTIME_CLASSPATH_CONFIGURATION_NAME)
+        Configuration consoleClasspath = project.configurations.getByName(CONSOLE_CONFIGURATION_NAME)
+        Configuration profileClasspath = project.configurations.getByName(PROFILE_CONFIGURATION_NAME)
 
         if (project.tasks.findByName('runScript') == null) {
             project.tasks.register('runScript', ApplicationContextScriptTask) { ApplicationContextScriptTask scriptTask ->
@@ -539,7 +539,7 @@ class GrailsGradlePlugin extends GroovyPlugin {
 
             project.tasks.withType(FindMainClassTask).configureEach { Task findMainClass ->
                 findMainClass.doLast {
-                    ExtraPropertiesExtension extraProperties = project.getExtensions().getByType(ExtraPropertiesExtension)
+                    ExtraPropertiesExtension extraProperties = project.extensions.getByType(ExtraPropertiesExtension)
                     def mainClassName = extraProperties.get('mainClassName')
                     if (mainClassName) {
                         project.tasks.withType(ApplicationContextScriptTask).configureEach { ApplicationContextScriptTask scriptTask ->
@@ -552,9 +552,9 @@ class GrailsGradlePlugin extends GroovyPlugin {
     }
 
     protected void configureRunCommand(Project project) {
-        Configuration runtimeClasspath = project.getConfigurations().getByName(JavaPlugin.RUNTIME_CLASSPATH_CONFIGURATION_NAME)
-        Configuration consoleClasspath = project.configurations.getByName(CONSOLE_CONFIGURATION)
-        Configuration profileClasspath = project.configurations.getByName(PROFILE_CONFIGURATION)
+        Configuration runtimeClasspath = project.configurations.getByName(JavaPlugin.RUNTIME_CLASSPATH_CONFIGURATION_NAME)
+        Configuration consoleClasspath = project.configurations.getByName(CONSOLE_CONFIGURATION_NAME)
+        Configuration profileClasspath = project.configurations.getByName(PROFILE_CONFIGURATION_NAME)
 
         if (project.tasks.findByName('runCommand') == null) {
             project.tasks.register('runCommand', ApplicationContextCommandTask) { ApplicationContextCommandTask commandTask ->
@@ -574,7 +574,7 @@ class GrailsGradlePlugin extends GroovyPlugin {
 
             project.tasks.withType(FindMainClassTask).configureEach { Task findMainClass ->
                 findMainClass.doLast {
-                    ExtraPropertiesExtension extraProperties = project.getExtensions().getByType(ExtraPropertiesExtension)
+                    ExtraPropertiesExtension extraProperties = project.extensions.getByType(ExtraPropertiesExtension)
                     def mainClassName = extraProperties.get('mainClassName')
                     if (mainClassName) {
                         project.tasks.withType(ApplicationContextCommandTask).configureEach { ApplicationContextCommandTask commandTask ->
@@ -590,7 +590,7 @@ class GrailsGradlePlugin extends GroovyPlugin {
         ConfigurationContainer configurations = project.configurations
         Configuration runtime = configurations.getByName(JavaPlugin.RUNTIME_CLASSPATH_CONFIGURATION_NAME)
         Configuration developmentOnly = configurations.findByName(SpringBootPlugin.DEVELOPMENT_ONLY_CONFIGURATION_NAME)
-        Configuration console = configurations.getByName(CONSOLE_CONFIGURATION)
+        Configuration console = configurations.getByName(CONSOLE_CONFIGURATION_NAME)
 
         Jar pathingJar = (Jar) project.tasks.findByName('pathingJar')
         Jar pathingJarCommand = (Jar) project.tasks.findByName('pathingJarCommand')

--- a/grace-gradle-plugin/src/main/groovy/org/grails/gradle/plugin/core/GrailsGradlePlugin.groovy
+++ b/grace-gradle-plugin/src/main/groovy/org/grails/gradle/plugin/core/GrailsGradlePlugin.groovy
@@ -277,6 +277,7 @@ class GrailsGradlePlugin extends GroovyPlugin {
                 commandTask.setDescription(commandDescription)
                 commandTask.classpath = buildClasspath(project, runtimeClasspath, consoleClasspath, profileClasspath)
                 commandTask.command = commandName
+                commandTask.dependsOn(JavaPlugin.CLASSES_TASK_NAME, FIND_MAIN_CLASS_TASK_NAME)
                 commandTask.systemProperty 'spring.main.banner-mode', 'OFF'
                 commandTask.systemProperty 'logging.level.ROOT', 'OFF'
                 commandTask.systemProperty 'spring.output.ansi.enabled', 'always'
@@ -526,6 +527,7 @@ class GrailsGradlePlugin extends GroovyPlugin {
                 scriptTask.group = 'Grace'
                 scriptTask.description = "Executes the Grace Application Scripts."
                 scriptTask.classpath = buildClasspath(project, runtimeClasspath, consoleClasspath, profileClasspath)
+                scriptTask.dependsOn(JavaPlugin.CLASSES_TASK_NAME, FIND_MAIN_CLASS_TASK_NAME)
                 scriptTask.systemProperty Environment.KEY, System.getProperty(Environment.KEY, Environment.DEVELOPMENT.getName())
                 scriptTask.systemProperty BuildSettings.APP_BASE_DIR, project.projectDir
                 scriptTask.systemProperty 'spring.main.banner-mode', 'OFF'
@@ -561,6 +563,7 @@ class GrailsGradlePlugin extends GroovyPlugin {
                 commandTask.group = 'Grace'
                 commandTask.description = "Executes the Grace Application Commands."
                 commandTask.classpath = buildClasspath(project, runtimeClasspath, consoleClasspath, profileClasspath)
+                commandTask.dependsOn(JavaPlugin.CLASSES_TASK_NAME, FIND_MAIN_CLASS_TASK_NAME)
                 commandTask.systemProperty Environment.KEY, System.getProperty(Environment.KEY, Environment.DEVELOPMENT.getName())
                 commandTask.systemProperty BuildSettings.APP_BASE_DIR, project.projectDir
                 commandTask.systemProperty 'spring.main.banner-mode', 'OFF'

--- a/grace-gradle-plugin/src/main/groovy/org/grails/gradle/plugin/profiles/GrailsProfileGradlePlugin.groovy
+++ b/grace-gradle-plugin/src/main/groovy/org/grails/gradle/plugin/profiles/GrailsProfileGradlePlugin.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2024 the original author or authors.
+ * Copyright 2015-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,6 +21,7 @@ import org.gradle.api.Project
 import org.gradle.api.artifacts.ConfigurablePublishArtifact
 import org.gradle.api.artifacts.Configuration
 import org.gradle.api.file.CopySpec
+import org.gradle.api.plugins.BasePlugin
 import org.gradle.api.plugins.GroovyPlugin
 import org.gradle.api.plugins.JavaPluginExtension
 import org.gradle.api.tasks.Copy
@@ -33,8 +34,6 @@ import grails.io.IOUtils
 import org.grails.cli.profile.commands.script.GroovyScriptCommand
 import org.grails.gradle.plugin.profiles.tasks.ProfileCompilerTask
 
-import static org.gradle.api.plugins.BasePlugin.BUILD_GROUP
-
 /**
  * A plugin that is capable of compiling a Grails profile into a JAR file for distribution
  *
@@ -45,33 +44,28 @@ import static org.gradle.api.plugins.BasePlugin.BUILD_GROUP
 @CompileStatic
 class GrailsProfileGradlePlugin implements Plugin<Project> {
 
-    static final String CONFIGURATION_NAME = 'grails'
-
-    public static final String RUNTIME_CONFIGURATION = 'profile'
+    public static final String GRAILS_CONFIGURATION_NAME = 'grails'
+    public static final String PROFILE_CONFIGURATION_NAME = 'profile'
 
     @Override
     void apply(Project project) {
         project.getPluginManager().apply(GroovyPlugin)
-        project.configurations.create(CONFIGURATION_NAME)
-        Configuration profileConfiguration = project.configurations.create(RUNTIME_CONFIGURATION)
+        project.configurations.create(GRAILS_CONFIGURATION_NAME)
+        Configuration profileConfiguration = project.configurations.create(PROFILE_CONFIGURATION_NAME)
         profileConfiguration.setCanBeConsumed(false)
         profileConfiguration.setCanBeResolved(true)
         profileConfiguration.setVisible(false)
-        project.getPlugins().withType(GroovyPlugin, { javaPlugin ->
-            SourceSetContainer sourceSets = project.getExtensions()
-                    .getByType(JavaPluginExtension).getSourceSets()
+        project.getPlugins().withType(GroovyPlugin).configureEach {
+            SourceSetContainer sourceSets = project.extensions.getByType(JavaPluginExtension).sourceSets
             sourceSets.configureEach { SourceSet sourceSet ->
-                project.getConfigurations()
-                        .getByName(sourceSet.getCompileClasspathConfigurationName())
+                project.configurations.getByName(sourceSet.compileClasspathConfigurationName)
                         .extendsFrom(profileConfiguration)
-                project.getConfigurations()
-                        .getByName(sourceSet.getImplementationConfigurationName())
+                project.configurations.getByName(sourceSet.implementationConfigurationName)
                         .extendsFrom(profileConfiguration)
-                project.getConfigurations()
-                        .getByName(sourceSet.getRuntimeClasspathConfigurationName())
+                project.configurations.getByName(sourceSet.runtimeClasspathConfigurationName)
                         .extendsFrom(profileConfiguration)
             }
-        })
+        }
 
         def profileYml = project.file('profile.yml')
 
@@ -104,7 +98,7 @@ class GrailsProfileGradlePlugin implements Plugin<Project> {
             c.into(new File(resourcesDir, '/META-INF/grails-profile'))
         })
 
-        def classesDir = project.layout.getBuildDirectory().dir('classes/profile').get().asFile
+        def classesDir = project.layout.buildDirectory.dir('classes/profile').get().asFile
         def compileProfileTask = project.tasks.register('compileProfile', ProfileCompilerTask, { ProfileCompilerTask task ->
             task.destinationDirectory.set(classesDir)
             task.source = commandsDir
@@ -113,10 +107,10 @@ class GrailsProfileGradlePlugin implements Plugin<Project> {
             if (templatesDir.exists()) {
                 task.templatesDir = templatesDir
             }
-            task.classpath = project.configurations.getByName(RUNTIME_CONFIGURATION) + project.files(IOUtils.findJarFile(GroovyScriptCommand))
+            task.classpath = project.configurations.getByName(PROFILE_CONFIGURATION_NAME) + project.files(IOUtils.findJarFile(GroovyScriptCommand))
         })
 
-        def groovyClassesDir = project.layout.getBuildDirectory().dir('classes/groovy/main').get().asFile
+        def groovyClassesDir = project.layout.buildDirectory.dir('classes/groovy/main').get().asFile
         def compileTask = project.tasks.getByName('compileGroovy')
         if (compileTask) {
             compileTask.dependsOn(compileProfileTask)
@@ -129,9 +123,9 @@ class GrailsProfileGradlePlugin implements Plugin<Project> {
             jarTask.from(resourcesDir)
             jarTask.from(classesDir)
             jarTask.from(groovyClassesDir)
-            jarTask.destinationDirectory.set(project.layout.getBuildDirectory().dir('libs'))
+            jarTask.destinationDirectory.set(project.layout.buildDirectory.dir('libs'))
             jarTask.setDescription('Assembles a jar archive containing the profile classes.')
-            jarTask.setGroup(BUILD_GROUP)
+            jarTask.setGroup(BasePlugin.BUILD_GROUP)
         }
         else {
             // Create jar task
@@ -140,13 +134,13 @@ class GrailsProfileGradlePlugin implements Plugin<Project> {
                 jar.from(resourcesDir)
                 jar.from(classesDir)
                 jar.from(groovyClassesDir)
-                jar.destinationDirectory.set(project.layout.getBuildDirectory().dir('libs'))
+                jar.destinationDirectory.set(project.layout.buildDirectory.dir('libs'))
                 jar.setDescription('Assembles a jar archive containing the profile classes.')
-                jar.setGroup(BUILD_GROUP)
+                jar.setGroup(BasePlugin.BUILD_GROUP)
             }).get()
         }
 
-        project.artifacts.add(CONFIGURATION_NAME, jarTask.getArchiveFile(),
+        project.artifacts.add(GRAILS_CONFIGURATION_NAME, jarTask.getArchiveFile(),
                 { ConfigurablePublishArtifact artifact -> artifact.builtBy(jarTask) })
 
         project.tasks.register('sourcesJar', Jar, { Jar jar ->
@@ -161,12 +155,12 @@ class GrailsProfileGradlePlugin implements Plugin<Project> {
                 spec.into('skeleton')
             }
             jar.archiveClassifier.set('sources')
-            jar.destinationDirectory.set(project.layout.getBuildDirectory().dir('libs'))
+            jar.destinationDirectory.set(project.layout.buildDirectory.dir('libs'))
             jar.setDescription('Assembles a jar archive containing the profile sources.')
-            jar.setGroup(BUILD_GROUP)
+            jar.setGroup(BasePlugin.BUILD_GROUP)
         })
 
-        project.tasks.findByName('assemble').dependsOn jarTask
+        project.tasks.named(BasePlugin.ASSEMBLE_TASK_NAME).configure { it.dependsOn jarTask }
     }
 
 }

--- a/grace-gradle-plugin/src/main/groovy/org/grails/gradle/plugin/profiles/tasks/ProfileCompilerTask.groovy
+++ b/grace-gradle-plugin/src/main/groovy/org/grails/gradle/plugin/profiles/tasks/ProfileCompilerTask.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2024 the original author or authors.
+ * Copyright 2015-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -105,7 +105,7 @@ class ProfileCompilerTask extends AbstractCompile {
 
         if (!profileData.containsKey('extends')) {
             List<String> dependencies = []
-            project.configurations.getByName(GrailsProfileGradlePlugin.RUNTIME_CONFIGURATION).allDependencies.all { Dependency d ->
+            project.configurations.getByName(GrailsProfileGradlePlugin.PROFILE_CONFIGURATION_NAME).allDependencies.all { Dependency d ->
                 dependencies.add("${d.group}:${d.name}:${d.version}".toString())
             }
             profileData.put('extends', dependencies.join(','))

--- a/grace-gradle-plugin/src/main/groovy/org/grails/gradle/plugin/web/gsp/GroovyPageForkCompileTask.groovy
+++ b/grace-gradle-plugin/src/main/groovy/org/grails/gradle/plugin/web/gsp/GroovyPageForkCompileTask.groovy
@@ -86,6 +86,7 @@ class GroovyPageForkCompileTask extends AbstractCompile {
     @Inject
     GroovyPageForkCompileTask(ExecOperations execOperations) {
         this.execOperations = execOperations
+        this.packageName = project.name ?: project.projectDir.canonicalFile.name
     }
 
     @Override
@@ -114,10 +115,6 @@ class GroovyPageForkCompileTask extends AbstractCompile {
     }
 
     protected void compile() {
-        if (packageName == null) {
-            packageName = project.name ?: project.projectDir.canonicalFile.name
-        }
-
         ExecResult result = this.execOperations.javaexec(
                 new Action<JavaExecSpec>() {
 

--- a/grace-gradle-plugin/src/main/groovy/org/grails/gradle/plugin/web/gsp/GroovyPagePlugin.groovy
+++ b/grace-gradle-plugin/src/main/groovy/org/grails/gradle/plugin/web/gsp/GroovyPagePlugin.groovy
@@ -15,13 +15,13 @@
  */
 package org.grails.gradle.plugin.web.gsp
 
-import groovy.transform.CompileDynamic
 import groovy.transform.CompileStatic
 import org.apache.tools.ant.taskdefs.condition.Os
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.artifacts.Configuration
 import org.gradle.api.file.FileCollection
+import org.gradle.api.plugins.JavaPlugin
 import org.gradle.api.tasks.SourceSet
 import org.gradle.api.tasks.SourceSetOutput
 import org.gradle.api.tasks.TaskContainer
@@ -30,6 +30,7 @@ import org.gradle.api.tasks.bundling.Jar
 import org.gradle.api.tasks.bundling.War
 
 import org.grails.gradle.plugin.core.GrailsExtension
+import org.grails.gradle.plugin.core.GrailsGradlePlugin
 import org.grails.gradle.plugin.util.SourceSets
 
 /**
@@ -42,25 +43,18 @@ import org.grails.gradle.plugin.util.SourceSets
 @CompileStatic
 class GroovyPagePlugin implements Plugin<Project> {
 
-    @CompileDynamic
     @Override
     void apply(Project project) {
         registerGrailsExtension(project)
-
-        project.configurations.create('gspCompile')
-        project.dependencies.add('gspCompile', 'jakarta.servlet:jakarta.servlet-api:6.0.0')
 
         SourceSet mainSourceSet = SourceSets.findMainSourceSet(project)
 
         SourceSetOutput output = mainSourceSet?.output
         FileCollection classesDirs = resolveClassesDirs(output, project)
-        File destDir = output?.dir('gsp-classes') ?: project.layout.buildDirectory.dir('gsp-classes/main').get().asFile
+        File destDir = project.layout.buildDirectory.dir('gsp-classes/main').get().asFile
 
-        Configuration providedConfig = project.configurations.findByName('providedCompile')
-        def allClasspath = project.configurations.compileClasspath + project.configurations.gspCompile + classesDirs
-        if (providedConfig) {
-            allClasspath += providedConfig
-        }
+        Configuration compileClasspath = project.configurations.findByName(JavaPlugin.COMPILE_CLASSPATH_CONFIGURATION_NAME)
+        FileCollection allClasspath = compileClasspath + classesDirs
 
         TaskContainer tasks = project.tasks
 
@@ -73,7 +67,7 @@ class GroovyPagePlugin implements Plugin<Project> {
             task.tmpDirPath = getTmpDirPath(project)
             task.serverpath = '/'
             task.classpath = allClasspath
-            task.dependsOn(tasks.named('classes'))
+            task.dependsOn(tasks.named(JavaPlugin.CLASSES_TASK_NAME))
         }
 
         TaskProvider<GroovyPageForkCompileTask> compileGroovyPages = tasks.register(
@@ -84,7 +78,7 @@ class GroovyPagePlugin implements Plugin<Project> {
             task.tmpDirPath = getTmpDirPath(project)
             task.serverpath = '/WEB-INF/grails-app/views/'
             task.classpath = allClasspath
-            task.dependsOn(tasks.named('classes'))
+            task.dependsOn(tasks.named(JavaPlugin.CLASSES_TASK_NAME))
             task.dependsOn(compileWebappGroovyPages)
         }
 
@@ -133,8 +127,8 @@ class GroovyPagePlugin implements Plugin<Project> {
     }
 
     protected GrailsExtension registerGrailsExtension(Project project) {
-        if (project.extensions.findByName('grails') == null) {
-            project.extensions.add('grails', new GrailsExtension(project))
+        if (project.extensions.findByName(GrailsGradlePlugin.GRAILS_EXTENSION_NAME) == null) {
+            project.extensions.add(GrailsGradlePlugin.GRAILS_EXTENSION_NAME, new GrailsExtension(project))
         }
     }
 


### PR DESCRIPTION
Refactor `GrailsGradlePlugin`

- Use `JavaPlugin.CLASSES_TASK_NAME` instead of `classes`
- Use Groovy style `project.configurations` and `project.extensions`
- Add `GRAILS_EXTENSION_NAME` `FIND_MAIN_CLASS_TASK_NAME` `BUILD_PROPERTIES_TASK_NAME`
- Rename `CONSOLE_CONFIGURATION` to `CONSOLE_CONFIGURATION_NAME`
- Rename `PROFILE_CONFIGURATION` to `PROFILE_CONFIGURATION_NAME`
- Remove `addDefaultProfile()`


Update ApplicationContextCommandTask and ApplicationContextScriptTask

- Remove `dependsOn` of the tasks `ApplicationContextCommandTask` and `ApplicationContextScriptTask`
- Configure `dependsOn` when registering the tasks


Refactor GrailsProfileGradlePlugin

- Use `BasePlugin.ASSEMBLE_TASK_NAME` instead of `assemble`
- Rename `CONFIGURATION_NAME` to `GRAILS_CONFIGURATION_NAME`
- Rename `RUNTIME_CONFIGURATION` to `PROFILE_CONFIGURATION_NAME`
- Use Groovy style `project.configurations` and `project.extensions`


Improve GroovyPagePlugin and GroovyPageForkCompileTask

- Remove unnecessary dependency on `jakarta.servlet-api`
- Remove Configuration `providedCompile`, only use `compileClasspath`
- Don't call `Task.getProject()` from a task action
- Use `JavaPlugin.CLASSES_TASK_NAME` instead of `classes`
- Use `GrailsGradlePlugin.GRAILS_EXTENSION_NAME`
