### PR TITLE
Refactor Gradle plugins

### DIFF
--- a/grace-gradle-plugin/src/main/groovy/org/grails/gradle/plugin/core/GrailsGradlePlugin.groovy
+++ b/grace-gradle-plugin/src/main/groovy/org/grails/gradle/plugin/core/GrailsGradlePlugin.groovy
@@ -713,7 +713,7 @@ withConfig(configuration) {
         SourceSetOutput output = mainSourceSet?.output
         FileCollection mainFiles = resolveClassesDirs(output, project)
         FileCollection fileCollection = project.files(project.layout.buildDirectory.dir('resources/main'),
-                project.layout.buildDirectory.dir('gsp-classes'), mainFiles)
+                project.layout.buildDirectory.dir('classes/gsp/main'), mainFiles)
         configurations.each {
             fileCollection = fileCollection + it.filter({ File file -> !file.name.startsWith('spring-boot-devtools') })
         }

--- a/grace-gradle-plugin/src/main/groovy/org/grails/gradle/plugin/run/FindMainClassTask.groovy
+++ b/grace-gradle-plugin/src/main/groovy/org/grails/gradle/plugin/run/FindMainClassTask.groovy
@@ -97,7 +97,7 @@ class FindMainClassTask extends DefaultTask {
     }
 
     protected FileCollection resolveClassesDirs(SourceSetOutput output, Project project) {
-        output?.classesDirs ?: project.files(project.layout.buildDirectory.dir('classes/main'))
+        output?.classesDirs ?: project.files(project.layout.buildDirectory.dir('classes/groovy/main'))
     }
 
     protected MainClassFinder createMainClassFinder() {

--- a/grace-gradle-plugin/src/main/groovy/org/grails/gradle/plugin/web/gsp/GroovyPagePlugin.groovy
+++ b/grace-gradle-plugin/src/main/groovy/org/grails/gradle/plugin/web/gsp/GroovyPagePlugin.groovy
@@ -15,10 +15,12 @@
  */
 package org.grails.gradle.plugin.web.gsp
 
+import groovy.transform.CompileDynamic
 import groovy.transform.CompileStatic
 import org.apache.tools.ant.taskdefs.condition.Os
 import org.gradle.api.Plugin
 import org.gradle.api.Project
+import org.gradle.api.Task
 import org.gradle.api.artifacts.Configuration
 import org.gradle.api.file.FileCollection
 import org.gradle.api.plugins.JavaPlugin
@@ -27,7 +29,6 @@ import org.gradle.api.tasks.SourceSetOutput
 import org.gradle.api.tasks.TaskContainer
 import org.gradle.api.tasks.TaskProvider
 import org.gradle.api.tasks.bundling.Jar
-import org.gradle.api.tasks.bundling.War
 
 import org.grails.gradle.plugin.core.GrailsExtension
 import org.grails.gradle.plugin.core.GrailsGradlePlugin
@@ -103,29 +104,7 @@ class GroovyPagePlugin implements Plugin<Project> {
             }
         }
 
-        tasks.withType(War) { War war ->
-            war.dependsOn compileGroovyPages
-            if (war.classpath) {
-                war.classpath = war.classpath + project.files(destDir)
-            }
-            else {
-                war.classpath = project.files(destDir)
-            }
-        }
-        tasks.withType(Jar) { Jar jar ->
-            if (!(jar instanceof War)) {
-                if (jar.name == 'bootJar') {
-                    jar.dependsOn compileGroovyPages
-                    jar.from(destDir) {
-                        into('BOOT-INF/classes')
-                    }
-                }
-                else if (jar.name == 'jar') {
-                    jar.dependsOn compileGroovyPages
-                    jar.from destDir
-                }
-            }
-        }
+        configureBootArchive(tasks, compileGroovyPages, destDir)
     }
 
     protected GrailsExtension registerGrailsExtension(Project project) {
@@ -140,6 +119,24 @@ class GroovyPagePlugin implements Plugin<Project> {
 
     protected String getTmpDirPath(Project project) {
         project.layout.buildDirectory.dir('tmp/gsp').get().asFile.absolutePath
+    }
+
+    /**
+     * Configure Spring Boot's BootArchive
+     *
+     * @param tasks the TaskContainer
+     * @param compileGroovyPages the GroovyPageForkCompileTask
+     * @param destDir the compiled gsp classes dir
+     * @see org.springframework.boot.gradle.tasks.bundling.BootArchive#classpath(Object... classpath)
+     */
+    @CompileDynamic
+    private void configureBootArchive(TaskContainer tasks, TaskProvider<? extends Task> compileGroovyPages, File destDir) {
+        tasks.withType(Jar).configureEach { Jar jar ->
+            if (jar.name in ['bootJar', 'bootWar']) {
+                jar.dependsOn(compileGroovyPages)
+                jar.classpath(destDir)
+            }
+        }
     }
 
 }

--- a/grace-gradle-plugin/src/main/groovy/org/grails/gradle/plugin/web/gsp/GroovyPagePlugin.groovy
+++ b/grace-gradle-plugin/src/main/groovy/org/grails/gradle/plugin/web/gsp/GroovyPagePlugin.groovy
@@ -133,7 +133,7 @@ class GroovyPagePlugin implements Plugin<Project> {
     }
 
     protected FileCollection resolveClassesDirs(SourceSetOutput output, Project project) {
-        output?.classesDirs ?: project.files(project.layout.buildDirectory.dir('classes/main'))
+        output?.classesDirs ?: project.files(project.layout.buildDirectory.dir('classes/groovy/main'))
     }
 
     protected String getTmpDirPath(Project project) {

--- a/grace-gradle-plugin/src/main/groovy/org/grails/gradle/plugin/web/gsp/GroovyPagePlugin.groovy
+++ b/grace-gradle-plugin/src/main/groovy/org/grails/gradle/plugin/web/gsp/GroovyPagePlugin.groovy
@@ -51,7 +51,7 @@ class GroovyPagePlugin implements Plugin<Project> {
 
         SourceSetOutput output = mainSourceSet?.output
         FileCollection classesDirs = resolveClassesDirs(output, project)
-        File destDir = project.layout.buildDirectory.dir('gsp-classes/main').get().asFile
+        File destDir = project.layout.buildDirectory.dir('classes/gsp/main').get().asFile
 
         Configuration compileClasspath = project.configurations.findByName(JavaPlugin.COMPILE_CLASSPATH_CONFIGURATION_NAME)
         FileCollection allClasspath = compileClasspath + classesDirs
@@ -137,7 +137,7 @@ class GroovyPagePlugin implements Plugin<Project> {
     }
 
     protected String getTmpDirPath(Project project) {
-        project.layout.buildDirectory.dir('gsptmp').get().asFile.absolutePath
+        project.layout.buildDirectory.dir('tmp/gsp').get().asFile.absolutePath
     }
 
 }

--- a/grace-gradle-plugin/src/main/groovy/org/grails/gradle/plugin/web/gsp/GroovyPagePlugin.groovy
+++ b/grace-gradle-plugin/src/main/groovy/org/grails/gradle/plugin/web/gsp/GroovyPagePlugin.groovy
@@ -64,6 +64,7 @@ class GroovyPagePlugin implements Plugin<Project> {
             task.description = "Compiles the Groovy server pages (GSP) in 'src/main/webapp'."
             task.destinationDirectory.set(destDir)
             task.source = project.file("src/main/webapp")
+            task.packageName = project.name
             task.tmpDirPath = getTmpDirPath(project)
             task.serverpath = '/'
             task.classpath = allClasspath
@@ -75,6 +76,7 @@ class GroovyPagePlugin implements Plugin<Project> {
             task.group = 'grace'
             task.description = 'Compiles the Groovy server pages (GSP).'
             task.destinationDirectory.set(destDir)
+            task.packageName = project.name
             task.tmpDirPath = getTmpDirPath(project)
             task.serverpath = '/WEB-INF/grails-app/views/'
             task.classpath = allClasspath

--- a/grace-gsp/src/main/groovy/org/grails/gsp/compiler/GroovyPageCompiler.groovy
+++ b/grace-gsp/src/main/groovy/org/grails/gsp/compiler/GroovyPageCompiler.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004-2023 the original author or authors.
+ * Copyright 2004-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -41,6 +41,7 @@ import org.grails.taglib.encoder.OutputEncodingSettings
  * Used to compile GSP files into a specified target directory.
  *
  * @author Graeme Rocher
+ * @author Michael Yan
  * @since 1.2
  */
 @CompileStatic
@@ -183,12 +184,15 @@ class GroovyPageCompiler {
 
         String relPackagePath = relativePath(viewsDir, gspfile.getParentFile())
 
-        String packageDir = "gsp/${packagePrefix}"
+        String packageDir = packagePrefix
         if (relPackagePath.length() > 0) {
             if (!packageDir.endsWith('/')) {
                 packageDir += '/'
             }
             packageDir += generateJavaName(relPackagePath)
+        }
+        if (!packageDir.endsWith('/')) {
+            packageDir += '/'
         }
         String className = generateJavaName(packageDir.replace('/', '_'))
         className += generateJavaName(gspfile.name)


### PR DESCRIPTION
* Correct the Groovy build classes dirs
* Change the compiled gsp classes target directory
* Change the generated gsp class name: remove the prefixed 'gsp', and append '_' before the view names
* Configure the classpath of the Spring Boot's BootArchive