### PR TITLE
Refactor Gradle plugins

### DIFF
--- a/grace-gradle-plugin/src/main/groovy/org/grails/gradle/plugin/core/GenerateBuildInfo.groovy
+++ b/grace-gradle-plugin/src/main/groovy/org/grails/gradle/plugin/core/GenerateBuildInfo.groovy
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2022-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.grails.gradle.plugin.core
+
+import groovy.transform.CompileStatic
+import org.gradle.api.DefaultTask
+import org.gradle.api.Task
+import org.gradle.api.file.DirectoryProperty
+import org.gradle.api.provider.MapProperty
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.OutputDirectory
+import org.gradle.api.tasks.TaskAction
+
+/**
+ * {@link Task} for generating a {@code grails.build.info} file from a
+ * {@code Project}.
+ *
+ * @author Michael Yan
+ * @since 2024.0.0
+ */
+@CompileStatic
+abstract class GenerateBuildInfo extends DefaultTask {
+
+    private static final String BUILD_INFO_FILE = 'META-INF/grails.build.info'
+
+    @Input
+    abstract MapProperty<String, Object> getProperties()
+
+    @OutputDirectory
+    abstract DirectoryProperty getDestinationDir()
+
+    @TaskAction
+    void execute() {
+        File buildInfoFile = new File(getDestinationDir().get().asFile, BUILD_INFO_FILE)
+        buildInfoFile.parentFile.mkdir()
+
+        Properties buildProperties = new Properties()
+        buildProperties.putAll(getProperties().getOrNull())
+
+        buildInfoFile.withOutputStream { OutputStream out ->
+            buildProperties.store(out, null)
+        }
+    }
+
+}

--- a/grace-gradle-plugin/src/main/groovy/org/grails/gradle/plugin/core/GenerateConfigScript.groovy
+++ b/grace-gradle-plugin/src/main/groovy/org/grails/gradle/plugin/core/GenerateConfigScript.groovy
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2022-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.grails.gradle.plugin.core
+
+import groovy.transform.CompileStatic
+import org.gradle.api.DefaultTask
+import org.gradle.api.Project
+import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.OutputFile
+import org.gradle.api.tasks.TaskAction
+
+/**
+ * Generate the Groovy configuration script for {@link org.gradle.api.tasks.compile.GroovyCompile}
+ *
+ * @author Michael Yan
+ * @since 2024.0.0
+ */
+@CompileStatic
+abstract class GenerateConfigScript extends DefaultTask {
+
+    @Input
+    abstract Property<String> getProjectName()
+
+    @Input
+    abstract Property<String> getProjectVersion()
+
+    @Input
+    abstract Property<String> getProjectType()
+
+    @Input
+    abstract Property<String> getProjectDir()
+
+    @Input
+    abstract Property<String> getGrailsAppDir()
+
+    @OutputFile
+    abstract RegularFileProperty getConfigFile()
+
+    GenerateConfigScript() {
+        Project project = getProject()
+        getProjectName().convention(project.provider(project::getName))
+    }
+
+    @TaskAction
+    void generateConfigScript() throws IOException {
+        String projectDir = getProjectDir().get()
+        String grailsAppDir = getGrailsAppDir().get()
+        if (System.getProperty('os.name').startsWith('Windows')) {
+            projectDir = projectDir.replace('\\', '\\\\')
+            grailsAppDir = grailsAppDir.replace('\\', '\\\\')
+        }
+        File configFile = getConfigFile().getAsFile().get()
+        configFile.parentFile.mkdirs()
+        configFile.text = """// A Groovy script file that configures the compiler, allowing extensive control over how the code is compiled.
+// Please see the Groovy compiler customization builder documentation for more information about the compiler configuration DSL.
+// https://docs.groovy-lang.org/latest/html/documentation/#compilation-customizers
+withConfig(configuration) {
+    inline(phase: 'CONVERSION') { source, context, classNode ->
+        source.ast.putNodeMetaData('PROJECT_NAME', '${getProjectName().get()}')
+        source.ast.putNodeMetaData('PROJECT_TYPE', '${getProjectType().get()}')
+        source.ast.putNodeMetaData('PROJECT_VERSION', '${getProjectVersion().get()}')
+        source.ast.putNodeMetaData('PROJECT_DIR', '${projectDir}')
+        source.ast.putNodeMetaData('GRAILS_APP_DIR', '${grailsAppDir}')
+    }
+}
+"""
+    }
+
+}

--- a/grace-gradle-plugin/src/main/groovy/org/grails/gradle/plugin/core/GrailsGradlePlugin.groovy
+++ b/grace-gradle-plugin/src/main/groovy/org/grails/gradle/plugin/core/GrailsGradlePlugin.groovy
@@ -184,33 +184,23 @@ class GrailsGradlePlugin extends GroovyPlugin {
         'web'
     }
 
-    @CompileDynamic
     protected void createBuildPropertiesTask(Project project) {
         if (project.tasks.findByName(BUILD_PROPERTIES_TASK_NAME) == null) {
             File resourcesDir = SourceSets.findMainSourceSet(project).output.resourcesDir
-            File buildInfoFile = new File(resourcesDir, 'META-INF/grails.build.info')
 
-            LinkedHashMap<String, Object> buildPropertiesContents = [
+            LinkedHashMap<String, Object> buildProperties = [
                     'grails.env': Environment.isSystemSet() ? Environment.current.getName() : Environment.PRODUCTION.getName(),
                     'info.app.name': project.name,
                     'info.app.version': project.version instanceof Serializable ? project.version : project.version.toString(),
                     'info.app.grailsVersion': grailsVersion]
 
-            TaskProvider<Task> buildPropertiesTask = project.tasks.register(BUILD_PROPERTIES_TASK_NAME) { Task task ->
+            TaskProvider<GenerateBuildInfo> buildPropertiesTask = project.tasks.register(BUILD_PROPERTIES_TASK_NAME, GenerateBuildInfo)
+                    { GenerateBuildInfo task ->
                 task.group = 'build'
                 task.description = "Build properties into 'META-INF/grails.build.info'."
-                task.inputs.properties(buildPropertiesContents)
-                task.outputs.file(buildInfoFile)
-                task.doLast {
-                    ant.mkdir(dir: buildInfoFile.parentFile)
-                    ant.propertyfile(file: buildInfoFile) {
-                        for (me in task.inputs.properties) {
-                            entry key: me.key, value: me.value
-                        }
-                    }
-                }
+                task.destinationDir.set(resourcesDir)
+                task.properties.set(buildProperties)
             }
-
             project.tasks.named(JavaPlugin.PROCESS_RESOURCES_TASK_NAME).configure {it.dependsOn(buildPropertiesTask) }
         }
     }

--- a/grace-gradle-plugin/src/main/groovy/org/grails/gradle/plugin/core/GrailsGradlePlugin.groovy
+++ b/grace-gradle-plugin/src/main/groovy/org/grails/gradle/plugin/core/GrailsGradlePlugin.groovy
@@ -133,7 +133,7 @@ class GrailsGradlePlugin extends GroovyPlugin {
 
         createBuildPropertiesTask(project)
 
-        configureGroovyASTMetadata(project)
+        configureGroovyCompiler(project)
     }
 
     protected void configureProfile(Project project) {
@@ -659,40 +659,18 @@ class GrailsGradlePlugin extends GroovyPlugin {
         }
     }
 
-    protected void configureGroovyASTMetadata(Project project) {
-        String projectName = getGrailsProjectName(project)
-        String projectVersion = project.version
-        String projectDir = project.projectDir.absolutePath
-        GrailsProjectType projectType = getGrailsProjectType()
+    protected void configureGroovyCompiler(Project project) {
         File configFile = project.layout.buildDirectory.file('config.groovy').get().asFile
 
-        TaskProvider<Task> configScriptTask = project.tasks.register('configScript') { Task configScript ->
+        TaskProvider<GenerateConfigScript> configScriptTask = project.tasks.register('configScript', GenerateConfigScript) {
+            GenerateConfigScript configScript ->
             configScript.group = 'Build Setup'
             configScript.description = 'Generates Groovy configuration script.'
-
-            configScript.outputs.file(configFile)
-            configScript.inputs.property('name', projectName)
-            configScript.inputs.property('version', projectVersion)
-            configScript.doLast {
-                String grailsAppPath = SourceSets.resolveGrailsAppPath(project)
-                String grailsAppDir = grailsAppPath ? project.file(grailsAppPath).absolutePath : ''
-                if (System.getProperty('os.name').startsWith('Windows')) {
-                    projectDir = projectDir.replace('\\', '\\\\')
-                    grailsAppDir = grailsAppDir.replace('\\', '\\\\')
-                }
-                configFile.parentFile.mkdirs()
-                configFile.text = """
-withConfig(configuration) {
-    inline(phase: 'CONVERSION') { source, context, classNode ->
-        source.ast.putNodeMetaData('GRAILS_APP_DIR', '$grailsAppDir')
-        source.ast.putNodeMetaData('PROJECT_DIR', '$projectDir')
-        source.ast.putNodeMetaData('PROJECT_NAME', '$projectName')
-        source.ast.putNodeMetaData('PROJECT_TYPE', '$projectType')
-        source.ast.putNodeMetaData('PROJECT_VERSION', '$projectVersion')
-    }
-}
-"""
-            }
+            configScript.configFile.set(configFile)
+            configScript.projectDir.set(project.projectDir.absolutePath)
+            configScript.projectType.set(getGrailsProjectType().toString())
+            configScript.projectVersion.set(project.getVersion().toString())
+            configScript.grailsAppDir.set(project.file(SourceSets.resolveGrailsAppPath(project)).absolutePath)
         }
         project.tasks.named('compileGroovy', GroovyCompile).configure {
             it.dependsOn(configScriptTask)


### PR DESCRIPTION
Refactor GrailsGradlePlugin

- Introduce `GenerateBuildInfo` and `GenerateConfigScript`
- Remove `@CompileDynamic` on `createBuildPropertiesTask()`
- Rename `configureGroovyASTMetadata()` to `configureGroovyCompiler()`