### PR TITLE
Refactor Gradle plugins

### DIFF
--- a/grace-gradle-plugin/src/main/groovy/org/grails/gradle/plugin/core/GrailsExtension.groovy
+++ b/grace-gradle-plugin/src/main/groovy/org/grails/gradle/plugin/core/GrailsExtension.groovy
@@ -55,12 +55,16 @@ class GrailsExtension {
 
     /**
      * Whether to invoke native2ascii on resource bundles
+     * @deprecated since 2024.0.0 in favor of Gradle's {@link org.gradle.language.jvm.tasks.ProcessResources}
      */
+    @Deprecated(since = '2024.0.0', forRemoval = true)
     boolean native2ascii = !Os.isFamily(Os.FAMILY_WINDOWS)
 
     /**
      * Whether to use Ant to do the conversion
+     * @deprecated since 2024.0.0 in favor of Gradle's {@link org.gradle.language.jvm.tasks.ProcessResources}
      */
+    @Deprecated(since = '2024.0.0', forRemoval = true)
     boolean native2asciiAnt = false
 
     /**

--- a/grace-gradle-plugin/src/main/groovy/org/grails/gradle/plugin/core/GrailsGradlePlugin.groovy
+++ b/grace-gradle-plugin/src/main/groovy/org/grails/gradle/plugin/core/GrailsGradlePlugin.groovy
@@ -21,8 +21,6 @@ import groovy.transform.CompileDynamic
 import groovy.transform.CompileStatic
 import io.spring.gradle.dependencymanagement.DependencyManagementPlugin
 import io.spring.gradle.dependencymanagement.dsl.DependencyManagementExtension
-import org.apache.tools.ant.filters.EscapeUnicode
-import org.apache.tools.ant.filters.ReplaceTokens
 import org.apache.tools.ant.taskdefs.condition.Os
 import org.gradle.api.GradleException
 import org.gradle.api.Plugin
@@ -30,7 +28,6 @@ import org.gradle.api.Project
 import org.gradle.api.Task
 import org.gradle.api.artifacts.Configuration
 import org.gradle.api.artifacts.ConfigurationContainer
-import org.gradle.api.file.DuplicatesStrategy
 import org.gradle.api.file.FileCollection
 import org.gradle.api.java.archives.Manifest
 import org.gradle.api.plugins.ExtraPropertiesExtension
@@ -46,7 +43,6 @@ import org.gradle.api.tasks.TaskProvider
 import org.gradle.api.tasks.bundling.Jar
 import org.gradle.api.tasks.compile.GroovyCompile
 import org.gradle.api.tasks.testing.Test
-import org.gradle.language.jvm.tasks.ProcessResources
 import org.gradle.process.JavaForkOptions
 import org.gradle.tooling.provider.model.ToolingModelBuilderRegistry
 import org.gradle.util.GradleVersion
@@ -121,8 +117,6 @@ class GrailsGradlePlugin extends GroovyPlugin {
         applyBasePlugins(project)
 
         registerFindMainClassTask(project)
-
-        enableNative2Ascii(project, grailsVersion)
 
         configureSpringBootExtension(project)
 
@@ -417,53 +411,6 @@ class GrailsGradlePlugin extends GroovyPlugin {
                 task.description = 'Finds the main class of the application.'
                 task.dependsOn(project.tasks.named(JavaPlugin.CLASSES_TASK_NAME), findMainClassTask)
                 findMainClassTask.finalizedBy(task)
-            }
-        }
-    }
-
-    /**
-     * Enables native2ascii processing of resource bundles
-     **/
-    @CompileDynamic
-    protected void enableNative2Ascii(Project project, String grailsVersion) {
-        Map<String, String> replaceTokens = [
-                'info.app.name': project.name,
-                'info.app.version': project.version?.toString(),
-                'info.app.grailsVersion': grailsVersion
-        ]
-
-        SourceSet sourceSet = SourceSets.findMainSourceSet(project)
-
-        project.afterEvaluate {
-            String grailsAppPath = SourceSets.resolveGrailsAppPath(project)
-            TaskContainer taskContainer = project.tasks
-
-            GrailsExtension grailsExt = project.extensions.getByType(GrailsExtension)
-            boolean native2ascii = grailsExt.isNative2ascii()
-
-            taskContainer.named(sourceSet.processResourcesTaskName, ProcessResources).configure { ProcessResources task ->
-                task.setDuplicatesStrategy(DuplicatesStrategy.INCLUDE)
-
-                if (native2ascii && grailsExt.isNative2asciiAnt()) {
-                    File i18nDir = project.file("${grailsAppPath}/i18n")
-                    File destinationDir = task.destinationDir
-                    ant.native2ascii(src: i18nDir, dest: destinationDir,
-                            includes: '**/*.properties', encoding: 'UTF-8')
-                }
-
-                if (!native2ascii) {
-                    task.from(sourceSet.resources) {
-                        include '**/*.properties'
-                        filter(ReplaceTokens, tokens: replaceTokens)
-                    }
-                }
-                else if (!grailsExt.isNative2asciiAnt()) {
-                    task.from(sourceSet.resources) {
-                        include '**/*.properties'
-                        filter(ReplaceTokens, tokens: replaceTokens)
-                        filter(EscapeUnicode)
-                    }
-                }
             }
         }
     }

--- a/grace-gradle-plugin/src/main/groovy/org/grails/gradle/plugin/core/GrailsGradlePlugin.groovy
+++ b/grace-gradle-plugin/src/main/groovy/org/grails/gradle/plugin/core/GrailsGradlePlugin.groovy
@@ -451,11 +451,6 @@ class GrailsGradlePlugin extends GroovyPlugin {
                             includes: '**/*.properties', encoding: 'UTF-8')
                 }
 
-                task.from(project.relativePath('src/main/templates')) {
-                    into('templates')
-                    include '**/*.gsp'
-                }
-
                 if (!native2ascii) {
                     task.from(sourceSet.resources) {
                         include '**/*.properties'
@@ -468,20 +463,6 @@ class GrailsGradlePlugin extends GroovyPlugin {
                         filter(ReplaceTokens, tokens: replaceTokens)
                         filter(EscapeUnicode)
                     }
-                }
-
-                task.from(sourceSet.resources) {
-                    filter(ReplaceTokens, tokens: replaceTokens)
-                    include '**/*.groovy'
-                    include '**/*.yml'
-                    include '**/*.xml'
-                }
-
-                task.from(sourceSet.resources) {
-                    exclude '**/*.properties'
-                    exclude '**/*.groovy'
-                    exclude '**/*.yml'
-                    exclude '**/*.xml'
                 }
             }
         }

--- a/grace-gradle-plugin/src/main/groovy/org/grails/gradle/plugin/core/GrailsPluginGradlePlugin.groovy
+++ b/grace-gradle-plugin/src/main/groovy/org/grails/gradle/plugin/core/GrailsPluginGradlePlugin.groovy
@@ -19,11 +19,14 @@ import javax.inject.Inject
 
 import groovy.transform.CompileDynamic
 import groovy.transform.CompileStatic
+import org.apache.tools.ant.filters.ReplaceTokens
 import org.gradle.api.Project
 import org.gradle.api.Task
 import org.gradle.api.artifacts.Configuration
 import org.gradle.api.artifacts.ConfigurationContainer
 import org.gradle.api.artifacts.PublishArtifact
+import org.gradle.api.file.CopySpec
+import org.gradle.api.file.Directory
 import org.gradle.api.file.DuplicatesStrategy
 import org.gradle.api.file.SourceDirectorySet
 import org.gradle.api.internal.tasks.DefaultTaskDependency
@@ -46,7 +49,7 @@ import org.springframework.boot.gradle.tasks.bundling.BootJar
 import org.springframework.boot.gradle.tasks.run.BootRun
 
 import grails.util.Environment
-
+import grails.util.GrailsNameUtils
 import org.grails.gradle.plugin.util.SourceSets
 
 /**
@@ -58,6 +61,10 @@ import org.grails.gradle.plugin.util.SourceSets
  */
 @CompileStatic
 class GrailsPluginGradlePlugin extends GrailsGradlePlugin {
+
+    public static final String PROCESS_PLUGIN_RESOURCES_TASK_NAME = 'processPluginResources'
+
+    public static final String PLUGIN_GROUP = 'plugin'
 
     @Inject
     GrailsPluginGradlePlugin(ToolingModelBuilderRegistry registry) {
@@ -163,21 +170,36 @@ class GrailsPluginGradlePlugin extends GrailsGradlePlugin {
     }
 
     protected void configurePluginResources(Project project) {
-        project.afterEvaluate {
-            ProcessResources processResources = (ProcessResources) project.tasks.findByName(JavaPlugin.PROCESS_RESOURCES_TASK_NAME)
+        Map<String, String> replaceTokens = [
+                'info.app.name': GrailsNameUtils.getScriptName(getGrailsProjectName(project)),
+                'info.app.version': project.version?.toString(),
+                'info.app.grailsVersion': grailsVersion
+        ]
+        SourceSetContainer sourceSets = project.extensions.getByType(JavaPluginExtension).sourceSets
+        SourceSet mainSourceSet = sourceSets.getByName(SourceSet.MAIN_SOURCE_SET_NAME)
+        File resourcesDir = mainSourceSet.getOutput().getResourcesDir()
+        Directory commandsDir = project.layout.projectDirectory.dir('src/main/scripts')
+        Directory templatesDir = project.layout.projectDirectory.dir('src/main/templates')
 
-            TaskProvider<Copy> copyCommands = project.tasks.register('copyCommands', Copy) {
-                it.from "${project.projectDir}/src/main/scripts"
-                it.into "${processResources.destinationDir}/META-INF/commands"
-            }
-            TaskProvider<Copy> copyTemplates = project.tasks.register('copyTemplates', Copy) {
-                it.from "${project.projectDir}/src/main/templates"
-                it.into "${processResources.destinationDir}/META-INF/templates"
-            }
+        TaskProvider<ProcessPluginResourcesTask> processPluginResources = project.tasks.register(PROCESS_PLUGIN_RESOURCES_TASK_NAME,
+                ProcessPluginResourcesTask) { ProcessPluginResourcesTask task ->
+            task.setGroup(PLUGIN_GROUP)
+            task.setDescription('Processes the Grace Plugin resources.')
+            task.commandsDir.set(commandsDir)
+            task.templatesDir.set(templatesDir)
+            task.destinationDir.set(resourcesDir)
+        }
 
-            processResources.setDuplicatesStrategy(DuplicatesStrategy.INCLUDE)
-            processResources.dependsOn(copyCommands, copyTemplates)
-            processResources.exclude('spring/resources.groovy', '**/*.gsp')
+        project.tasks.named(mainSourceSet.getProcessResourcesTaskName(), Copy).configure { Copy copy ->
+            copy.dependsOn(processPluginResources)
+            copy.setDuplicatesStrategy(DuplicatesStrategy.INCLUDE)
+            copy.exclude('spring/resources.groovy')
+            copy.from(mainSourceSet.resources) { CopySpec spec ->
+                spec.filter(ReplaceTokens, tokens: replaceTokens)
+                spec.include('**/*.groovy')
+                spec.include('**/*.yml')
+                spec.include('**/*.xml')
+            }
         }
     }
 
@@ -185,6 +207,7 @@ class GrailsPluginGradlePlugin extends GrailsGradlePlugin {
         project.tasks.named(JavaPlugin.JAR_TASK_NAME, Jar).configure { Jar jarTask ->
             jarTask.enabled = true
             jarTask.archiveClassifier.set('plugin')
+            jarTask.includeEmptyDirs = false
             jarTask.exclude('application.yml', 'application.groovy', 'logback.groovy', 'logback.xml', 'logback-spring.xml')
         }
     }

--- a/grace-gradle-plugin/src/main/groovy/org/grails/gradle/plugin/core/GrailsPluginGradlePlugin.groovy
+++ b/grace-gradle-plugin/src/main/groovy/org/grails/gradle/plugin/core/GrailsPluginGradlePlugin.groovy
@@ -19,6 +19,7 @@ import javax.inject.Inject
 
 import groovy.transform.CompileDynamic
 import groovy.transform.CompileStatic
+import org.apache.tools.ant.filters.EscapeUnicode
 import org.apache.tools.ant.filters.ReplaceTokens
 import org.gradle.api.Project
 import org.gradle.api.Task
@@ -199,6 +200,11 @@ class GrailsPluginGradlePlugin extends GrailsGradlePlugin {
                 spec.include('**/*.groovy')
                 spec.include('**/*.yml')
                 spec.include('**/*.xml')
+            }
+            copy.from(mainSourceSet.resources) { CopySpec spec ->
+                spec.include('**/messages*.properties')
+                spec.filter(ReplaceTokens, tokens: replaceTokens)
+                spec.filter(EscapeUnicode)
             }
         }
     }

--- a/grace-gradle-plugin/src/main/groovy/org/grails/gradle/plugin/core/ProcessPluginResourcesTask.groovy
+++ b/grace-gradle-plugin/src/main/groovy/org/grails/gradle/plugin/core/ProcessPluginResourcesTask.groovy
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2022-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.grails.gradle.plugin.core
+
+import javax.inject.Inject
+
+import groovy.transform.CompileStatic
+import org.gradle.api.DefaultTask
+import org.gradle.api.Task
+import org.gradle.api.file.CopySpec
+import org.gradle.api.file.DirectoryProperty
+import org.gradle.api.file.FileSystemOperations
+import org.gradle.api.file.SyncSpec
+import org.gradle.api.tasks.InputFiles
+import org.gradle.api.tasks.Optional
+import org.gradle.api.tasks.OutputDirectory
+import org.gradle.api.tasks.TaskAction
+import org.gradle.work.DisableCachingByDefault
+
+/**
+ * {@link Task} for processing the resources of the Plugin
+ *
+ * @author Michael Yan
+ * @since 2024.0.0
+ */
+@CompileStatic
+@DisableCachingByDefault(because = "Not worth caching")
+abstract class ProcessPluginResourcesTask extends DefaultTask {
+
+    private final FileSystemOperations fileSystemOperations
+
+    @Optional
+    @InputFiles
+    abstract DirectoryProperty getCommandsDir()
+
+    @Optional
+    @InputFiles
+    abstract DirectoryProperty getTemplatesDir()
+
+    @OutputDirectory
+    abstract DirectoryProperty getDestinationDir()
+
+    @Inject
+    ProcessPluginResourcesTask(FileSystemOperations fileSystemOperations) {
+        this.fileSystemOperations = fileSystemOperations
+    }
+
+    @TaskAction
+    void processResources() throws IOException {
+        CopySpec copyCommands = this.fileSystemOperations.copySpec { spec ->
+            spec.from(commandsDir)
+            spec.into('commands')
+        }
+
+        CopySpec copyTemplates = this.fileSystemOperations.copySpec { spec ->
+            spec.from(templatesDir)
+            spec.into('templates')
+        }
+
+        this.fileSystemOperations.sync { SyncSpec copy ->
+            copy.with(copyCommands, copyTemplates)
+            copy.into(destinationDir.dir('META-INF'))
+        }
+    }
+
+}

--- a/grace-gradle-plugin/src/main/groovy/org/grails/gradle/plugin/web/GrailsWebGradlePlugin.groovy
+++ b/grace-gradle-plugin/src/main/groovy/org/grails/gradle/plugin/web/GrailsWebGradlePlugin.groovy
@@ -18,6 +18,7 @@ package org.grails.gradle.plugin.web
 import javax.inject.Inject
 
 import groovy.transform.CompileStatic
+import org.apache.tools.ant.filters.EscapeUnicode
 import org.apache.tools.ant.filters.ReplaceTokens
 import org.gradle.api.Project
 import org.gradle.api.file.CopySpec
@@ -81,6 +82,11 @@ class GrailsWebGradlePlugin extends GrailsGradlePlugin {
                 spec.include('**/*.groovy')
                 spec.include('**/*.yml')
                 spec.include('**/*.xml')
+            }
+            copy.from(mainSourceSet.resources) { CopySpec spec ->
+                spec.include('**/messages*.properties')
+                spec.filter(ReplaceTokens, tokens: replaceTokens)
+                spec.filter(EscapeUnicode)
             }
         }
     }

--- a/grace-gradle-plugin/src/main/groovy/org/grails/gradle/plugin/web/GrailsWebGradlePlugin.groovy
+++ b/grace-gradle-plugin/src/main/groovy/org/grails/gradle/plugin/web/GrailsWebGradlePlugin.groovy
@@ -18,7 +18,14 @@ package org.grails.gradle.plugin.web
 import javax.inject.Inject
 
 import groovy.transform.CompileStatic
+import org.apache.tools.ant.filters.ReplaceTokens
 import org.gradle.api.Project
+import org.gradle.api.file.CopySpec
+import org.gradle.api.file.DuplicatesStrategy
+import org.gradle.api.plugins.JavaPluginExtension
+import org.gradle.api.tasks.Copy
+import org.gradle.api.tasks.SourceSet
+import org.gradle.api.tasks.SourceSetContainer
 import org.gradle.tooling.provider.model.ToolingModelBuilderRegistry
 
 import org.grails.gradle.plugin.core.GrailsGradlePlugin
@@ -51,9 +58,33 @@ class GrailsWebGradlePlugin extends GrailsGradlePlugin {
         configureRunCommand(project)
 
         configurePathingJar(project)
+
+        configureProcessResources(project)
     }
 
-    @Override
+    protected configureProcessResources(Project project) {
+        Map<String, String> replaceTokens = [
+                'info.app.name': project.name,
+                'info.app.version': project.version?.toString(),
+                'info.app.grailsVersion': grailsVersion
+        ]
+        SourceSetContainer sourceSets = project.extensions.getByType(JavaPluginExtension).sourceSets
+        SourceSet mainSourceSet = sourceSets.getByName(SourceSet.MAIN_SOURCE_SET_NAME)
+        project.tasks.named(mainSourceSet.processResourcesTaskName, Copy).configure { Copy copy ->
+            copy.setDuplicatesStrategy(DuplicatesStrategy.INCLUDE)
+            copy.from(project.relativePath('src/main/templates')) { CopySpec spec ->
+                spec.into('templates')
+                spec.include('**/*.gsp')
+            }
+            copy.from(mainSourceSet.resources) { CopySpec spec ->
+                spec.filter(ReplaceTokens, tokens: replaceTokens)
+                spec.include('**/*.groovy')
+                spec.include('**/*.yml')
+                spec.include('**/*.xml')
+            }
+        }
+    }
+
     protected GrailsProjectType getGrailsProjectType() {
         GrailsProjectType.WEB_APP
     }


### PR DESCRIPTION
Refine GrailsGradlePlugin, GrailsPluginGradlePlugin, GrailsWebGradlePlugin

- Add `ProcessPluginResourcesTask`
- Refine `configurePluginResources()`
- Don't exclude *.gsp in the templates
- Remove `enableNative2Ascii()` in favor of using Gradle's `ProcessResources`
- Deprecated `native2ascii` and `native2asciiAnt` in `GrailsExtension`