### PR TITLE
Refactor Grace Banner

### DIFF
--- a/grace-boot/src/main/groovy/grails/boot/GrailsResourceBanner.java
+++ b/grace-boot/src/main/groovy/grails/boot/GrailsResourceBanner.java
@@ -16,11 +16,14 @@
 package grails.boot;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
 import org.springframework.boot.ResourceBanner;
+import org.springframework.boot.ansi.AnsiPropertySource;
+import org.springframework.core.env.ConfigurableEnvironment;
 import org.springframework.core.env.Environment;
 import org.springframework.core.env.MapPropertySource;
 import org.springframework.core.env.MutablePropertySources;
@@ -33,7 +36,7 @@ import grails.util.Metadata;
 
 /**
  * Banner implementation that prints from a source text {@link Resource}.
- * Add extra properties related Grails, such as Grails version, application name and version.
+ * Add extra properties related Grails, such as Grails version, application name, title and version.
  *
  * @author Michael Yan
  * @since 2022.0.0
@@ -47,48 +50,106 @@ public class GrailsResourceBanner extends ResourceBanner {
 
     @Override
     protected List<PropertyResolver> getPropertyResolvers(Environment environment, Class<?> sourceClass) {
-        List<PropertyResolver> resolvers = new ArrayList<>(super.getPropertyResolvers(environment, sourceClass));
-        resolvers.add(getGrailsVersionResolver(environment));
+        List<PropertyResolver> resolvers = new ArrayList<>();
+        resolvers.add(new PropertySourcesPropertyResolver(createNullDefaultSources(environment, sourceClass)));
+        resolvers.add(new PropertySourcesPropertyResolver(createEmptyDefaultSources(environment, sourceClass)));
         return resolvers;
     }
 
-    private PropertyResolver getGrailsVersionResolver(Environment environment) {
-        MutablePropertySources propertySources = new MutablePropertySources();
-        propertySources.addLast(new MapPropertySource("grace-name", getNamesMap(environment, "")));
-        propertySources.addLast(new MapPropertySource("grace-version", getVersionsMap(environment, "")));
-        return new PropertySourcesPropertyResolver(propertySources);
+    private MutablePropertySources createNullDefaultSources(Environment environment, Class<?> sourceClass) {
+        MutablePropertySources nullDefaultSources = new MutablePropertySources();
+        if (environment instanceof ConfigurableEnvironment configurableEnvironment) {
+            configurableEnvironment.getPropertySources().forEach(nullDefaultSources::addLast);
+        }
+        nullDefaultSources.addLast(getNameSource(sourceClass, environment, null));
+        nullDefaultSources.addLast(getTitleSource(sourceClass, environment, null));
+        nullDefaultSources.addLast(getAnsiSource());
+        nullDefaultSources.addLast(getVersionSource(sourceClass, environment, null));
+        return nullDefaultSources;
     }
 
-    private Map<String, Object> getNamesMap(Environment environment, String defaultValue) {
+    private MutablePropertySources createEmptyDefaultSources(Environment environment, Class<?> sourceClass) {
+        MutablePropertySources emptyDefaultSources = new MutablePropertySources();
+        emptyDefaultSources.addLast(getNameSource(sourceClass, environment, ""));
+        emptyDefaultSources.addLast(getTitleSource(sourceClass, environment, ""));
+        emptyDefaultSources.addLast(getVersionSource(sourceClass, environment, ""));
+        return emptyDefaultSources;
+    }
+
+    private MapPropertySource getNameSource(Class<?> sourceClass, Environment environment, String defaultValue) {
+        String applicationName = getApplicationName(sourceClass, environment);
+        Map<String, Object> nameMap = Collections.singletonMap("application.name",
+                (applicationName != null) ? applicationName : defaultValue);
+        return new MapPropertySource("name", nameMap);
+    }
+
+    protected String getApplicationName(Class<?> sourceClass, Environment environment) {
         String applicationName = environment.getProperty("info.app.name");
+        if (applicationName == null) {
+            applicationName = environment.getProperty("spring.application.name");
+        }
         if (applicationName == null) {
             applicationName = Metadata.getCurrent().getApplicationName();
         }
-        if (applicationName == null) {
-            applicationName = defaultValue;
-        }
-        Map<String, Object> names = new HashMap<>();
-        names.put("application.name", applicationName);
-        return names;
+        return applicationName;
     }
 
-    private Map<String, Object> getVersionsMap(Environment environment, String defaultValue) {
+    private MapPropertySource getTitleSource(Class<?> sourceClass, Environment environment, String defaultValue) {
+        String applicationTitle = getApplicationTitle(sourceClass);
+        if (applicationTitle == null) {
+            applicationTitle = getApplicationTitle(environment);
+        }
+        Map<String, Object> titleMap = Collections.singletonMap("application.title",
+                (applicationTitle != null) ? applicationTitle : defaultValue);
+        return new MapPropertySource("title", titleMap);
+    }
+
+    protected String getApplicationTitle(Environment environment) {
+        return environment.getProperty("info.app.title");
+    }
+
+    private AnsiPropertySource getAnsiSource() {
+        return new AnsiPropertySource("ansi", true);
+    }
+
+    private MapPropertySource getVersionSource(Class<?> sourceClass, Environment environment, String defaultValue) {
+        return new MapPropertySource("version", getVersionsMap(sourceClass, environment, defaultValue));
+    }
+
+    private Map<String, Object> getVersionsMap(Class<?> sourceClass, Environment environment, String defaultValue) {
         String appVersion = getApplicationVersion(environment);
         Map<String, Object> versions = new HashMap<>();
-        String grailsVersion = GrailsUtil.getGrailsVersion();
+        String bootVersion = getBootVersion();
+        String grailsVersion = getGrailsVersion();
         versions.put("application.version", getVersionString(appVersion, false, defaultValue));
         versions.put("grace.version", getVersionString(grailsVersion, false, defaultValue));
+        versions.put("spring-boot.version", getVersionString(bootVersion, false, defaultValue));
         versions.put("application.formatted-version", getVersionString(appVersion, true, defaultValue));
         versions.put("grace.formatted-version", getVersionString(grailsVersion, true, defaultValue));
+        versions.put("spring-boot.formatted-version", getVersionString(bootVersion, true, defaultValue));
         return versions;
+    }
+
+    @SuppressWarnings("removal")
+    @Deprecated(since = "2024.0.0", forRemoval = true)
+    protected String getApplicationVersion(Class<?> sourceClass) {
+        String applicationVersion = Metadata.getCurrent().getApplicationVersion();
+        return (applicationVersion != null) ? applicationVersion : super.getApplicationVersion(sourceClass);
     }
 
     private String getApplicationVersion(Environment environment) {
         String appVersion = environment.getProperty("info.app.version");
         if (appVersion == null) {
+            appVersion = environment.getProperty("spring.application.version");
+        }
+        if (appVersion == null) {
             appVersion = Metadata.getCurrent().getApplicationVersion();
         }
         return appVersion;
+    }
+
+    protected String getGrailsVersion() {
+        return GrailsUtil.getGrailsVersion();
     }
 
     private String getVersionString(String version, boolean format, String fallback) {

--- a/grace-boot/src/main/groovy/grails/boot/GrailsResourceBanner.java
+++ b/grace-boot/src/main/groovy/grails/boot/GrailsResourceBanner.java
@@ -48,40 +48,52 @@ public class GrailsResourceBanner extends ResourceBanner {
     @Override
     protected List<PropertyResolver> getPropertyResolvers(Environment environment, Class<?> sourceClass) {
         List<PropertyResolver> resolvers = new ArrayList<>(super.getPropertyResolvers(environment, sourceClass));
-        resolvers.add(getGrailsVersionResolver(sourceClass));
+        resolvers.add(getGrailsVersionResolver(environment));
         return resolvers;
     }
 
-    private PropertyResolver getGrailsVersionResolver(Class<?> sourceClass) {
+    private PropertyResolver getGrailsVersionResolver(Environment environment) {
         MutablePropertySources propertySources = new MutablePropertySources();
-        propertySources.addLast(new MapPropertySource("grace-name", getNamesMap(sourceClass)));
-        propertySources.addLast(new MapPropertySource("grace-version", getVersionsMap(sourceClass)));
+        propertySources.addLast(new MapPropertySource("grace-name", getNamesMap(environment, "")));
+        propertySources.addLast(new MapPropertySource("grace-version", getVersionsMap(environment, "")));
         return new PropertySourcesPropertyResolver(propertySources);
     }
 
-    private Map<String, Object> getNamesMap(Class<?> sourceClass) {
-        String applicationName = Metadata.getCurrent().getApplicationName();
+    private Map<String, Object> getNamesMap(Environment environment, String defaultValue) {
+        String applicationName = environment.getProperty("info.app.name");
+        if (applicationName == null) {
+            applicationName = Metadata.getCurrent().getApplicationName();
+        }
+        if (applicationName == null) {
+            applicationName = defaultValue;
+        }
         Map<String, Object> names = new HashMap<>();
         names.put("application.name", applicationName);
         return names;
     }
 
-    private Map<String, Object> getVersionsMap(Class<?> sourceClass) {
+    private Map<String, Object> getVersionsMap(Environment environment, String defaultValue) {
+        String appVersion = getApplicationVersion(environment);
         Map<String, Object> versions = new HashMap<>();
         String grailsVersion = GrailsUtil.getGrailsVersion();
-        versions.put("grace.version", getVersionString(grailsVersion, false));
-        versions.put("grace.formatted-version", getVersionString(grailsVersion, true));
+        versions.put("application.version", getVersionString(appVersion, false, defaultValue));
+        versions.put("grace.version", getVersionString(grailsVersion, false, defaultValue));
+        versions.put("application.formatted-version", getVersionString(appVersion, true, defaultValue));
+        versions.put("grace.formatted-version", getVersionString(grailsVersion, true, defaultValue));
         return versions;
     }
 
-    protected String getApplicationVersion(Class<?> sourceClass) {
-        String applicationVersion = Metadata.getCurrent().getApplicationVersion();
-        return (applicationVersion != null) ? applicationVersion : super.getApplicationVersion(sourceClass);
+    private String getApplicationVersion(Environment environment) {
+        String appVersion = environment.getProperty("info.app.version");
+        if (appVersion == null) {
+            appVersion = Metadata.getCurrent().getApplicationVersion();
+        }
+        return appVersion;
     }
 
-    private String getVersionString(String version, boolean format) {
+    private String getVersionString(String version, boolean format, String fallback) {
         if (version == null) {
-            return "";
+            return fallback;
         }
         return format ? " (v" + version + ")" : version;
     }

--- a/grace-boot/src/test/groovy/grails/boot/GrailsResourceBannerTests.java
+++ b/grace-boot/src/test/groovy/grails/boot/GrailsResourceBannerTests.java
@@ -1,0 +1,293 @@
+/*
+ * Copyright 2012-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package grails.boot;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.boot.ResourceBanner;
+import org.springframework.boot.ansi.AnsiOutput;
+import org.springframework.boot.ansi.AnsiOutput.Enabled;
+import org.springframework.core.env.AbstractPropertyResolver;
+import org.springframework.core.env.Environment;
+import org.springframework.core.env.MapPropertySource;
+import org.springframework.core.env.PropertyResolver;
+import org.springframework.core.io.ByteArrayResource;
+import org.springframework.core.io.Resource;
+import org.springframework.mock.env.MockEnvironment;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for {@link GrailsResourceBanner}, copied from Spring Boot's ResourceBannerTests.
+ *
+ * @author Phillip Webb
+ * @author Vedran Pavic
+ * @author Toshiaki Maki
+ * @author Krzysztof Krason
+ * @author Michael Yan
+ * @since 2024.0.0
+ */
+class GrailsResourceBannerTests {
+
+    @AfterEach
+    void reset() {
+        AnsiOutput.setEnabled(Enabled.DETECT);
+    }
+
+    @Test
+    void renderGrailsVersions() {
+        Resource resource = new ByteArrayResource(
+                "banner ${a} ${grace.version} ${spring-boot.version} ${application.version}".getBytes());
+        String banner = printBanner(resource, "2024.0", "10.2", "2.0", null, null);
+        assertThat(banner).startsWith("banner 1 2024.0 10.2 2.0");
+    }
+
+    @Test
+    void renderVersions() {
+        Resource resource = new ByteArrayResource(
+                "banner ${a} ${spring-boot.version} ${application.version}".getBytes());
+        String banner = printBanner(resource, "10.2", "2.0", null);
+        assertThat(banner).startsWith("banner 1 10.2 2.0");
+    }
+
+    @Test
+    void renderWithoutVersions() {
+        Resource resource = new ByteArrayResource(
+                "banner ${a} ${grace.version} ${spring-boot.version} ${application.version}".getBytes());
+        String banner = printBanner(resource, null, null, null, null, null);
+        assertThat(banner).startsWith("banner 1  ");
+    }
+
+    @Test
+    void renderWithoutVersionsWithDefaultValues() {
+        Resource resource = new ByteArrayResource(
+                "banner ${a} ${grace.version:M.m.p} ${spring-boot.version:X.Y.Z} ${application.version:A.B.C}".getBytes());
+        String banner = printBanner(resource, null, null, null, null, null);
+        assertThat(banner).startsWith("banner 1 M.m.p X.Y.Z A.B.C");
+    }
+
+    @Test
+    void renderFormattedVersions() {
+        Resource resource = new ByteArrayResource(
+                "banner ${a}${grace.formatted-version}${spring-boot.formatted-version}${application.formatted-version}".getBytes());
+        String banner = printBanner(resource, "2024.0", "10.2", "2.0", null, null);
+        assertThat(banner).startsWith("banner 1 (v2024.0) (v10.2) (v2.0)");
+    }
+
+    @Test
+    void renderWithoutFormattedVersions() {
+        Resource resource = new ByteArrayResource(
+                "banner ${a} ${grace.formatted-version} ${spring-boot.formatted-version} ${application.formatted-version}".getBytes());
+        String banner = printBanner(resource, null, null, null, null, null);
+        assertThat(banner).startsWith("banner 1  ");
+    }
+
+    @Test
+    void renderWithoutFormattedVersionsWithDefaultValues() {
+        Resource resource = new ByteArrayResource(
+                "banner ${a} ${grace.formatted-version:(vM.m.p)} ${spring-boot.formatted-version:(vX.Y.Z)} ${application.formatted-version:(vA.B.C)}"
+                        .getBytes());
+        String banner = printBanner(resource, null, null, null, null, null);
+        assertThat(banner).startsWith("banner 1 (vM.m.p) (vX.Y.Z) (vA.B.C)");
+    }
+
+    @Test
+    void renderWithColors() {
+        Resource resource = new ByteArrayResource("${Ansi.RED}This is red.${Ansi.NORMAL}".getBytes());
+        AnsiOutput.setEnabled(AnsiOutput.Enabled.ALWAYS);
+        String banner = printBanner(resource, null, null, null);
+        assertThat(banner).startsWith("\u001B[31mThis is red.\u001B[0m");
+    }
+
+    @Test
+    void renderWithColorsButDisabled() {
+        Resource resource = new ByteArrayResource("${Ansi.RED}This is red.${Ansi.NORMAL}".getBytes());
+        AnsiOutput.setEnabled(AnsiOutput.Enabled.NEVER);
+        String banner = printBanner(resource, null, null, null);
+        assertThat(banner).startsWith("This is red.");
+    }
+
+    @Test
+    void renderWith256Colors() {
+        Resource resource = new ByteArrayResource("${AnsiColor.208}This is orange.${Ansi.NORMAL}".getBytes());
+        AnsiOutput.setEnabled(AnsiOutput.Enabled.ALWAYS);
+        String banner = printBanner(resource, null, null, null);
+        assertThat(banner).startsWith("\033[38;5;208mThis is orange.\u001B[0m");
+    }
+
+    @Test
+    void renderWith256ColorsButDisabled() {
+        Resource resource = new ByteArrayResource("${AnsiColor.208}This is orange.${Ansi.NORMAL}".getBytes());
+        AnsiOutput.setEnabled(AnsiOutput.Enabled.NEVER);
+        String banner = printBanner(resource, null, null, null);
+        assertThat(banner).startsWith("This is orange.");
+    }
+
+    @Test
+    void renderWithName() {
+        Resource resource = new ByteArrayResource("banner ${application.name} ${a}".getBytes());
+        String banner = printBanner(resource, null, null, null, null, "name");
+        assertThat(banner).startsWith("banner name 1");
+    }
+
+    @Test
+    void renderWithoutName() {
+        Resource resource = new ByteArrayResource("banner ${application.name} ${a}".getBytes());
+        String banner = printBanner(resource, null, null, null, null, null);
+        assertThat(banner).startsWith("banner  1");
+    }
+
+    @Test
+    void renderWithoutNameWithDefaultValue() {
+        Resource resource = new ByteArrayResource("banner ${application.name:Default Name} ${a}".getBytes());
+        String banner = printBanner(resource, null, null, null, null, null);
+        assertThat(banner).startsWith("banner Default Name 1");
+    }
+
+    @Test
+    void renderWithTitle() {
+        Resource resource = new ByteArrayResource("banner ${application.title} ${a}".getBytes());
+        String banner = printBanner(resource, null, null, "title");
+        assertThat(banner).startsWith("banner title 1");
+    }
+
+    @Test
+    void renderWithoutTitle() {
+        Resource resource = new ByteArrayResource("banner ${application.title} ${a}".getBytes());
+        String banner = printBanner(resource, null, null, null);
+        assertThat(banner).startsWith("banner  1");
+    }
+
+    @Test
+    void renderWithoutTitleWithDefaultValue() {
+        Resource resource = new ByteArrayResource("banner ${application.title:Default Title} ${a}".getBytes());
+        String banner = printBanner(resource, null, null, null);
+        assertThat(banner).startsWith("banner Default Title 1");
+    }
+
+    @Test
+    void renderWithDefaultValues() {
+        Resource resource = new ByteArrayResource(
+                "banner ${a:default-a} ${b:default-b} ${spring-boot.version:default-boot-version} ${application.version:default-application-version}"
+                        .getBytes());
+        String banner = printBanner(resource, "10.2", "1.0", null);
+        assertThat(banner).startsWith("banner 1 default-b 10.2 1.0");
+    }
+
+    @Test
+    void renderWithMutation() {
+        Resource resource = new ByteArrayResource("banner ${foo}".getBytes());
+        String banner = printBanner(new MutatingResourceBanner(resource, "1", null), "2", null);
+        assertThat(banner).startsWith("banner bar");
+    }
+
+    private String printBanner(Resource resource, String bootVersion, String applicationVersion, String applicationTitle) {
+        return printBanner(new MockResourceBanner(resource, null, bootVersion, applicationTitle), applicationVersion, null);
+    }
+
+    private String printBanner(Resource resource, String grailsVersion, String bootVersion, String applicationVersion,
+            String applicationTitle, String applicationName) {
+        return printBanner(new MockResourceBanner(resource, grailsVersion, bootVersion, applicationTitle), applicationVersion, applicationName);
+    }
+
+    private String printBanner(ResourceBanner banner, String applicationVersion, String applicationName) {
+        MockEnvironment environment = new MockEnvironment();
+        if (applicationVersion != null) {
+            environment.setProperty("info.app.version", applicationVersion);
+        }
+        if (applicationName != null) {
+            environment.setProperty("info.app.name", applicationName);
+        }
+        Map<String, Object> source = Collections.singletonMap("a", "1");
+        environment.getPropertySources().addLast(new MapPropertySource("map", source));
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        banner.printBanner(environment, getClass(), new PrintStream(out));
+        return out.toString();
+    }
+
+    static class MockResourceBanner extends GrailsResourceBanner {
+
+        private final String grailsVersion;
+
+        private final String bootVersion;
+
+        private final String applicationTitle;
+
+        MockResourceBanner(Resource resource, String grailsVersion, String bootVersion, String applicationTitle) {
+            super(resource);
+            this.grailsVersion = grailsVersion;
+            this.bootVersion = bootVersion;
+            this.applicationTitle = applicationTitle;
+        }
+
+        @Override
+        protected String getGrailsVersion() {
+            return this.grailsVersion;
+        }
+
+        @Override
+        protected String getBootVersion() {
+            return this.bootVersion;
+        }
+
+        @Override
+        protected String getApplicationTitle(Class<?> sourceClass) {
+            return this.applicationTitle;
+        }
+
+    }
+
+    static class MutatingResourceBanner extends MockResourceBanner {
+
+        MutatingResourceBanner(Resource resource, String bootVersion, String applicationTitle) {
+            super(resource, null, bootVersion, applicationTitle);
+        }
+
+        MutatingResourceBanner(Resource resource, String grailsVersion, String bootVersion, String applicationTitle) {
+            super(resource, grailsVersion, bootVersion, applicationTitle);
+        }
+
+        @Override
+        protected List<PropertyResolver> getPropertyResolvers(Environment environment, Class<?> sourceClass) {
+            List<PropertyResolver> resolvers = super.getPropertyResolvers(environment, sourceClass);
+            PropertyResolver resolver = new AbstractPropertyResolver() {
+
+                @Override
+                @SuppressWarnings("unchecked")
+                public <T> T getProperty(String key, Class<T> targetType) {
+                    return String.class.equals(targetType) ? (T) getPropertyAsRawString(key) : null;
+                }
+
+                @Override
+                protected String getPropertyAsRawString(String key) {
+                    return ("foo".equals(key)) ? "bar" : null;
+                }
+
+            };
+            resolvers.add(resolver);
+            return resolvers;
+        }
+
+    }
+
+}

--- a/grace-bootstrap/src/main/groovy/grails/util/Metadata.groovy
+++ b/grace-bootstrap/src/main/groovy/grails/util/Metadata.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004-2024 the original author or authors.
+ * Copyright 2004-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -47,7 +47,6 @@ class Metadata {
     public static final String FILE = 'application.yml'
     public static final String APPLICATION_VERSION = 'info.app.version'
     public static final String APPLICATION_NAME = 'info.app.name'
-    public static final String DEFAULT_APPLICATION_NAME = 'grailsApplication'
     public static final String APPLICATION_GRAILS_VERSION = 'info.app.grailsVersion'
     public static final String SERVLET_VERSION = 'info.app.servletVersion'
     public static final String DEFAULT_SERVLET_VERSION = '6.0'
@@ -173,7 +172,7 @@ class Metadata {
      * @return The application name
      */
     String getApplicationName() {
-        getProperty(APPLICATION_NAME, String, DEFAULT_APPLICATION_NAME)
+        getProperty(APPLICATION_NAME, String, null)
     }
 
     /**


### PR DESCRIPTION
Refactor GrailsResourceBanner

- Compatible with Spring Boot's `ResourceBanner`
- Add the ansi and title properties
- Add Spring Boot version
- Align with Spring Boot's `ResourceBanner`
- Don't return the default application name in `Metadata.getApplicationName()`
- Add GrailsResourceBannerTests