### PR TITLE
Refactor GrailsApplication

### DIFF
--- a/grace-api/src/main/groovy/grails/core/GrailsApplication.java
+++ b/grace-api/src/main/groovy/grails/core/GrailsApplication.java
@@ -28,11 +28,11 @@ import org.grails.datastore.mapping.model.MappingContext;
  * main purpose is to provide a mechanism for analysing the conventions within a Grails
  * application as well as providing metadata and information about the execution environment.
  *
- * <p>The GrailsApplication interface interfacts with {@link ArtefactHandler} instances
+ * <p>The GrailsApplication interface interacts with {@link ArtefactHandler} instances
  * which are capable of analysing different artefact types (controllers, domain classes etc.) and introspecting
  * the artefact conventions
  *
- * <p>Implementors of this inteface should be aware that a GrailsApplication is only initialised when the initialise() method
+ * <p>Implementors of this interface should be aware that a GrailsApplication is only initialised when the initialise() method
  * is called. In other words GrailsApplication instances are lazily initialised by the Grails runtime.
  *
  * @see #initialise()
@@ -99,7 +99,7 @@ public interface GrailsApplication extends ApplicationContextAware {
 
     /**
      * Returns the Spring context for this application. Note that this
-     * will return <code>null</code> until the application is fully
+     * will return {@code null} until the application is fully
      * initialised. This context contains all the application artifacts,
      * plugin beans, the works.
      */
@@ -130,7 +130,7 @@ public interface GrailsApplication extends ApplicationContextAware {
     ApplicationContext getParentContext();
 
     /**
-     * Retrieves a class for the given name within the GrailsApplication or returns null
+     * Retrieves a class for the given name within the GrailsApplication or returns {@code null}
      *
      * @param className The name of the class
      * @return The class or null
@@ -145,7 +145,7 @@ public interface GrailsApplication extends ApplicationContextAware {
     /**
      * Rebuilds this Application throwing away the class loader and re-constructing it from the loaded
      * resources again. Can only be called in development mode and an error will be thrown if called
-     * in a different enivronment
+     * in a different environment
      */
     void rebuild();
 
@@ -186,7 +186,7 @@ public interface GrailsApplication extends ApplicationContextAware {
 
     /**
      * <p>Gets the GrailsClass associated with the named artefact class</p>
-     * <p>i.e. to get the GrailsClass for  controller called "BookController" you pass the name "BookController"</p>
+     * <p>i.e. to get the GrailsClass for controller called "BookController" you pass the name "BookController"</p>
      * @param artefactType The type of artefact to retrieve, i.e. "Controller"
      * @param name The name of an artefact such as "BookController"
      * @return The associated GrailsClass or null
@@ -278,7 +278,7 @@ public interface GrailsApplication extends ApplicationContextAware {
 
     /**
      * Retrieves an artefact by its logical property name. For example the logical property name of
-     * BookController would be book.
+     * BookController would be 'book'.
      * @param type The artefact type
      * @param logicalName The logical name
      * @return The GrailsClass or null if it doesn't exist
@@ -299,13 +299,13 @@ public interface GrailsApplication extends ApplicationContextAware {
     boolean isWarDeployed();
 
     /**
-     * Adds an artefact that can be overriden by user defined classes
+     * Adds an artefact that can be overridden by user defined classes
      * @param artefact An overridable artefact
      */
     void addOverridableArtefact(Class<?> artefact);
 
     /**
-     * Fired to inform the application when the Config.groovy file changes.
+     * Fired to inform the application when the config files changed.
      */
     void configChanged();
 

--- a/grace-api/src/main/groovy/grails/core/GrailsApplication.java
+++ b/grace-api/src/main/groovy/grails/core/GrailsApplication.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004-2022 the original author or authors.
+ * Copyright 2004-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -50,24 +50,6 @@ public interface GrailsApplication extends ApplicationContextAware {
      * The id of the grails application within a bean context
      */
     String APPLICATION_ID = "grailsApplication";
-
-    /**
-     * The name of the class that provides configuration
-     */
-    @Deprecated
-    String CONFIG_CLASS = "Config";
-
-    /**
-     * The name of the DataSource class
-     */
-    @Deprecated
-    String DATA_SOURCE_CLASS = "DataSource";
-
-    /**
-     * The name of the project metadata file
-     */
-    @Deprecated
-    String PROJECT_META_FILE = "application.properties";
 
     /**
      * The name of the transaction manager bean

--- a/grace-api/src/main/groovy/grails/core/GrailsApplication.java
+++ b/grace-api/src/main/groovy/grails/core/GrailsApplication.java
@@ -20,7 +20,6 @@ import org.springframework.context.ApplicationContextAware;
 import org.springframework.core.io.Resource;
 
 import grails.config.Config;
-import grails.util.Metadata;
 
 import org.grails.datastore.mapping.model.MappingContext;
 
@@ -41,7 +40,7 @@ import org.grails.datastore.mapping.model.MappingContext;
  *
  * @author Graeme Rocher
  * @author Steven Devijver
- *
+ * @author Michael Yan
  * @since 0.1
  */
 public interface GrailsApplication extends ApplicationContextAware {
@@ -276,14 +275,6 @@ public interface GrailsApplication extends ApplicationContextAware {
      * @return true if it has been initialised
      */
     boolean isInitialised();
-
-    /**
-     * <p>Get access to the project's metadata, specified in application.yml and grails.build.info if it is present</p>
-     * <p>This provides access to information like required grails version, application name, version etc
-     * but <b>NOT</b> general application settings.</p>
-     * @return A read-only Map of data about the application, not environment specific
-     */
-    Metadata getMetadata();
 
     /**
      * Retrieves an artefact by its logical property name. For example the logical property name of

--- a/grace-core/src/main/groovy/grails/core/DefaultGrailsApplication.java
+++ b/grace-core/src/main/groovy/grails/core/DefaultGrailsApplication.java
@@ -366,7 +366,7 @@ public class DefaultGrailsApplication extends AbstractGrailsApplication implemen
     }
 
     /**
-     * Refreshes this GrailsApplication, rebuilding all of the artefact definitions as
+     * Refreshes this GrailsApplication, rebuilding all the artefact definitions as
      * defined by the registered ArtefactHandler instances.
      */
     public void refresh() {
@@ -473,7 +473,7 @@ public class DefaultGrailsApplication extends AbstractGrailsApplication implemen
     }
 
     /**
-     * Returns all of the GrailsClass instances for the given artefactType as defined by the ArtefactHandler
+     * Returns all the GrailsClass instances for the given artefactType as defined by the ArtefactHandler
      *
      * @param artefactType The type of the artefact defined by the ArtefactHandler
      * @return An array of classes for the given artefact
@@ -525,7 +525,7 @@ public class DefaultGrailsApplication extends AbstractGrailsApplication implemen
      * Registers a new ArtefactHandler that is responsible for identifying and managing a
      * particular artefact type that is defined by some convention.
      *
-     * @param handler The ArtefactHandler to regster
+     * @param handler The ArtefactHandler to register
      */
     public void registerArtefactHandler(ArtefactHandler handler) {
         this.artefactHandlersByName.put(handler.getType(), handler);

--- a/grace-core/src/main/groovy/org/grails/core/AbstractGrailsApplication.java
+++ b/grace-core/src/main/groovy/org/grails/core/AbstractGrailsApplication.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2023 the original author or authors.
+ * Copyright 2014-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -34,7 +34,6 @@ import grails.core.GrailsApplication;
 import grails.core.support.GrailsConfigurationAware;
 import grails.util.Environment;
 import grails.util.Holders;
-import grails.util.Metadata;
 
 import org.grails.config.PropertySourcesConfig;
 
@@ -47,8 +46,6 @@ public abstract class AbstractGrailsApplication extends GroovyObjectSupport
 
     protected ApplicationContext parentContext;
 
-    protected final Metadata applicationMeta = Metadata.getCurrent();
-
     protected boolean contextInitialized;
 
     @Override
@@ -57,11 +54,6 @@ public abstract class AbstractGrailsApplication extends GroovyObjectSupport
         if (applicationContext instanceof ConfigurableApplicationContext) {
             ((ConfigurableApplicationContext) applicationContext).addApplicationListener(this);
         }
-    }
-
-    @Override
-    public Metadata getMetadata() {
-        return this.applicationMeta;
     }
 
     @Override

--- a/grace-plugin-api/src/main/groovy/grails/plugins/DefaultGrailsPluginManager.java
+++ b/grace-plugin-api/src/main/groovy/grails/plugins/DefaultGrailsPluginManager.java
@@ -53,6 +53,7 @@ import grails.core.support.ParentApplicationContextAware;
 import grails.plugins.exceptions.PluginException;
 import grails.util.Environment;
 import grails.util.GrailsClassUtils;
+import grails.util.Metadata;
 
 import org.grails.core.exceptions.GrailsConfigurationException;
 import org.grails.io.support.GrailsResourceUtils;
@@ -453,7 +454,7 @@ public class DefaultGrailsPluginManager extends AbstractGrailsPluginManager {
             return true;
         }
 
-        String appGrailsVersion = this.application.getMetadata().getGrailsVersion();
+        String appGrailsVersion = Metadata.getCurrent().getGrailsVersion();
         String pluginMinGrailsVersion = GrailsVersionUtils.getLowerVersion(pluginGrailsVersion);
         String pluginMaxGrailsVersion = GrailsVersionUtils.getUpperVersion(pluginGrailsVersion);
 

--- a/grace-plugin-api/src/main/groovy/org/grails/plugins/AbstractGrailsPluginManager.java
+++ b/grace-plugin-api/src/main/groovy/org/grails/plugins/AbstractGrailsPluginManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004-2024 the original author or authors.
+ * Copyright 2004-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -68,6 +68,7 @@ import grails.plugins.module.ModuleType;
 import grails.util.BuildSettings;
 import grails.util.Environment;
 import grails.util.GrailsNameUtils;
+import grails.util.Metadata;
 
 import org.grails.config.NavigableMap;
 import org.grails.io.support.GrailsResourceUtils;
@@ -627,8 +628,8 @@ public abstract class AbstractGrailsPluginManager implements GrailsPluginManager
         binding.put(CONFIG_BINDING_USER_HOME, System.getProperty("user.home"));
         binding.put(CONFIG_BINDING_GRAILS_HOME, System.getProperty("grails.home"));
         if (application != null) {
-            binding.put(CONFIG_BINDING_APP_NAME, application.getMetadata().getApplicationName());
-            binding.put(CONFIG_BINDING_APP_VERSION, application.getMetadata().getApplicationVersion());
+            binding.put(CONFIG_BINDING_APP_NAME, Metadata.getCurrent().getApplicationName());
+            binding.put(CONFIG_BINDING_APP_VERSION, Metadata.getCurrent().getApplicationVersion());
             binding.put(GrailsApplication.APPLICATION_ID, application);
         }
         configSlurper.setBinding(binding);

--- a/grace-plugin-api/src/test/groovy/grails/plugins/DefaultGrailsPluginManagerSpec.groovy
+++ b/grace-plugin-api/src/test/groovy/grails/plugins/DefaultGrailsPluginManagerSpec.groovy
@@ -55,7 +55,7 @@ class DefaultGrailsPluginManagerSpec extends Specification {
 
     def stubGrailsApplicationWithVersion(def version) {
         GrailsApplication app = Mock(GrailsApplication)
-        app.getMetadata() >> Metadata.getInstance(new ByteArrayInputStream("""
+        Metadata.getCurrent() >> Metadata.getInstance(new ByteArrayInputStream("""
 info:
     app:
         grailsVersion: $version

--- a/grace-plugin-datasource/src/main/groovy/org/grails/plugins/datasource/TomcatJDBCPoolMBeanExporter.groovy
+++ b/grace-plugin-datasource/src/main/groovy/org/grails/plugins/datasource/TomcatJDBCPoolMBeanExporter.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004-2022 the original author or authors.
+ * Copyright 2004-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,6 +27,7 @@ import org.springframework.jmx.export.MBeanExporter
 import org.springframework.jmx.support.RegistrationPolicy
 
 import grails.core.GrailsApplication
+import grails.util.Metadata
 
 @CompileStatic
 class TomcatJDBCPoolMBeanExporter extends MBeanExporter {
@@ -72,7 +73,7 @@ class TomcatJDBCPoolMBeanExporter extends MBeanExporter {
             throws MalformedObjectNameException {
         Hashtable<String, String> properties = new Hashtable<String, String>()
         properties.type = 'ConnectionPool'
-        properties.application = ((grailsApplication?.getMetadata()?.getApplicationName()) ?: 'grailsApplication')
+        properties.application = ((Metadata.getCurrent().getApplicationName()) ?: 'grailsApplication')
                 .replaceAll(/[,=;:]/, '_')
         String poolName = dataSource.pool.poolProperties.name
 

--- a/grace-web/src/main/groovy/grails/web/servlet/context/support/GrailsEnvironment.java
+++ b/grace-web/src/main/groovy/grails/web/servlet/context/support/GrailsEnvironment.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2022 the original author or authors.
+ * Copyright 2011-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,11 +24,13 @@ import org.springframework.web.context.support.StandardServletEnvironment;
 
 import grails.core.GrailsApplication;
 import grails.util.Environment;
+import grails.util.Metadata;
 
 /**
  * Bridges Grails' existing environment API with the new Spring 3.1 environment profiles API.
  *
  * @author Graeme Rocher
+ * @author Michael Yan
  * @since 2.0
  */
 public class GrailsEnvironment extends StandardServletEnvironment {
@@ -51,8 +53,8 @@ public class GrailsEnvironment extends StandardServletEnvironment {
     protected class GrailsConfigPropertySource extends PropertySource<GrailsApplication> {
 
         public GrailsConfigPropertySource() {
-            super(StringUtils.hasText(GrailsEnvironment.this.grailsApplication.getMetadata().getApplicationName())
-                    ? GrailsEnvironment.this.grailsApplication.getMetadata().getApplicationName()
+            super(StringUtils.hasText(Metadata.getCurrent().getApplicationName())
+                    ? Metadata.getCurrent().getApplicationName()
                     : "grailsApplication", GrailsEnvironment.this.grailsApplication);
         }
 


### PR DESCRIPTION
Remove deprecated constants in GrailsApplication

- CONFIG_CLASS
- DATA_SOURCE_CLASS
- PROJECT_META_FILE

Remove method `getMetadata()` in GrailsApplication

- `GrailsApplication` should not depend on `Metadata`, please use `Metadata.getCurrent()` instead

Fix doc typos
