### PR TITLE
Cleanup dependencies

### DIFF
--- a/grace-plugin-fields/build.gradle
+++ b/grace-plugin-fields/build.gradle
@@ -1,8 +1,9 @@
 dependencies {
+    api project(":grace-plugin-validation")
     api project(":grace-scaffolding-core")
     api project(":grace-web-databinding")
     api project(":grace-web-gsp")
-    api project(":grace-plugin-validation")
+    api project(":grace-web-taglib")
     implementation libs.grace.datastore.core
     implementation libs.grace.datastore.gorm
     implementation libs.grace.datastore.gorm.support

--- a/grace-web-common/build.gradle
+++ b/grace-web-common/build.gradle
@@ -5,8 +5,6 @@ dependencies {
     api project(":grace-encoder")
     api project(":grace-util")
 
-    api project(":grace-gsp")
-
     compileOnlyApi libs.jakarta.servlet
     api libs.groovy.templates
     api libs.spring.contextSupport

--- a/grace-web-common/src/main/groovy/org/grails/web/servlet/DefaultGrailsApplicationAttributes.java
+++ b/grace-web-common/src/main/groovy/org/grails/web/servlet/DefaultGrailsApplicationAttributes.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004-2023 the original author or authors.
+ * Copyright 2004-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -39,7 +39,6 @@ import grails.util.Holders;
 import grails.web.mvc.FlashScope;
 import grails.web.pages.GroovyPagesUriService;
 
-import org.grails.gsp.ResourceAwareTemplateEngine;
 import org.grails.web.pages.DefaultGroovyPagesUriService;
 import org.grails.web.util.GrailsApplicationAttributes;
 
@@ -64,9 +63,6 @@ public class DefaultGrailsApplicationAttributes implements GrailsApplicationAttr
 
     private ApplicationContext appContext;
 
-    // Beans used very often
-    private ResourceAwareTemplateEngine pagesTemplateEngine;
-
     private GrailsApplication grailsApplication;
 
     private GroovyPagesUriService groovyPagesUriService;
@@ -85,6 +81,7 @@ public class DefaultGrailsApplicationAttributes implements GrailsApplicationAttr
         }
     }
 
+    @Override
     public ApplicationContext getApplicationContext() {
         return this.appContext;
     }
@@ -115,6 +112,7 @@ public class DefaultGrailsApplicationAttributes implements GrailsApplicationAttr
         }
     }
 
+    @Override
     public String getPluginContextPath(HttpServletRequest request) {
         GroovyObject controller = getController(request);
         if (controller != null && getPluginManager() != null) {
@@ -125,10 +123,12 @@ public class DefaultGrailsApplicationAttributes implements GrailsApplicationAttr
         return "";
     }
 
+    @Override
     public GroovyObject getController(ServletRequest request) {
         return (GroovyObject) request.getAttribute(CONTROLLER);
     }
 
+    @Override
     public String getControllerUri(ServletRequest request) {
         return "/" + getControllerName(request);
     }
@@ -166,10 +166,12 @@ public class DefaultGrailsApplicationAttributes implements GrailsApplicationAttr
         return appUri;
     }
 
+    @Override
     public ServletContext getServletContext() {
         return this.context;
     }
 
+    @Override
     public FlashScope getFlashScope(ServletRequest request) {
         if (!(request instanceof HttpServletRequest)) {
             return null;
@@ -196,35 +198,30 @@ public class DefaultGrailsApplicationAttributes implements GrailsApplicationAttr
         return fs;
     }
 
+    @Override
     public String getTemplateUri(CharSequence templateName, ServletRequest request) {
         Assert.notNull(templateName, "Argument [template] cannot be null");
         return getGroovyPagesUriService().getTemplateURI(getControllerName(request), templateName.toString());
     }
 
+    @Override
     public String getViewUri(String viewName, HttpServletRequest request) {
         Assert.notNull(viewName, "Argument [view] cannot be null");
         return getGroovyPagesUriService().getDeployedViewURI(getControllerName(request), viewName);
     }
 
+    @Override
     public String getControllerActionUri(ServletRequest request) {
         GroovyObject controller = getController(request);
         return (String) controller.getProperty("actionUri");
     }
 
+    @Override
     public Errors getErrors(ServletRequest request) {
         return (Errors) request.getAttribute(ERRORS);
     }
 
-    public ResourceAwareTemplateEngine getPagesTemplateEngine() {
-        if (this.pagesTemplateEngine == null) {
-            this.pagesTemplateEngine = fetchBeanFromAppCtx(ResourceAwareTemplateEngine.BEAN_ID);
-        }
-        if (this.pagesTemplateEngine == null && logger.isWarnEnabled()) {
-            logger.warn("No bean named [" + ResourceAwareTemplateEngine.BEAN_ID + "] defined in Spring application context!");
-        }
-        return this.pagesTemplateEngine;
-    }
-
+    @Override
     public GrailsApplication getGrailsApplication() {
         if (this.grailsApplication == null) {
             this.grailsApplication = fetchBeanFromAppCtx(GrailsApplication.APPLICATION_ID);
@@ -235,18 +232,22 @@ public class DefaultGrailsApplicationAttributes implements GrailsApplicationAttr
         return this.grailsApplication;
     }
 
+    @Override
     public Writer getOut(HttpServletRequest request) {
         return (Writer) request.getAttribute(OUT);
     }
 
+    @Override
     public void setOut(HttpServletRequest request, Writer out2) {
         request.setAttribute(OUT, out2);
     }
 
+    @Override
     public String getNoSuffixViewURI(GroovyObject controller, String viewName) {
         return getGroovyPagesUriService().getNoSuffixViewURI(controller, viewName);
     }
 
+    @Override
     public String getTemplateURI(GroovyObject controller, String templateName) {
         return getGroovyPagesUriService().getTemplateURI(controller, templateName);
     }
@@ -256,6 +257,7 @@ public class DefaultGrailsApplicationAttributes implements GrailsApplicationAttr
         return getGroovyPagesUriService().getTemplateURI(controller, templateName, includeExtension);
     }
 
+    @Override
     public GroovyPagesUriService getGroovyPagesUriService() {
         if (this.groovyPagesUriService == null) {
             this.groovyPagesUriService = fetchBeanFromAppCtx(GroovyPagesUriService.BEAN_ID);
@@ -266,6 +268,7 @@ public class DefaultGrailsApplicationAttributes implements GrailsApplicationAttr
         return this.groovyPagesUriService;
     }
 
+    @Override
     public MessageSource getMessageSource() {
         if (this.messageSource == null) {
             this.messageSource = fetchBeanFromAppCtx("messageSource");

--- a/grace-web-common/src/main/groovy/org/grails/web/util/GrailsApplicationAttributes.java
+++ b/grace-web-common/src/main/groovy/org/grails/web/util/GrailsApplicationAttributes.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004-2023 the original author or authors.
+ * Copyright 2004-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,8 +28,6 @@ import org.springframework.validation.Errors;
 import grails.core.ApplicationAttributes;
 import grails.web.mvc.FlashScope;
 import grails.web.pages.GroovyPagesUriService;
-
-import org.grails.gsp.ResourceAwareTemplateEngine;
 
 /**
  * Defines the names of and methods to retrieve Grails specific request and servlet attributes.
@@ -199,11 +197,6 @@ public interface GrailsApplicationAttributes extends ApplicationAttributes {
      * @return The errors instance contained within the request
      */
     Errors getErrors(ServletRequest request);
-
-    /**
-     * @return Retrieves the shared GSP template engine
-     */
-    ResourceAwareTemplateEngine getPagesTemplateEngine();
 
     /**
      * Holds the current response write for the request

--- a/grace-web-gsp/build.gradle
+++ b/grace-web-gsp/build.gradle
@@ -3,7 +3,6 @@ dependencies {
     compileOnlyApi libs.jakarta.servlet
     api project(":grace-gsp")
     api project(":grace-web-common")
-    api project(":grace-web-taglib")
     api project(":grace-web-sitemesh")
 
     testImplementation libs.jakarta.servlet

--- a/grace-web-mvc/build.gradle
+++ b/grace-web-mvc/build.gradle
@@ -1,8 +1,9 @@
 dependencies {
     api project(":grace-web-common")
+    api project(":grace-gsp")
+    api project(":grace-web-sitemesh")
     api project(":grace-web-url-mappings")
 
-    api project(":grace-web-sitemesh")
     compileOnlyApi libs.jakarta.servlet
 
     testImplementation libs.jakarta.servlet

--- a/grace-web-mvc/src/main/groovy/org/grails/web/errors/ErrorsViewStackTracePrinter.groovy
+++ b/grace-web-mvc/src/main/groovy/org/grails/web/errors/ErrorsViewStackTracePrinter.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2022 the original author or authors.
+ * Copyright 2011-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/grace-web-mvc/src/main/groovy/org/grails/web/errors/GrailsExceptionResolver.java
+++ b/grace-web-mvc/src/main/groovy/org/grails/web/errors/GrailsExceptionResolver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004-2023 the original author or authors.
+ * Copyright 2004-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -107,10 +107,12 @@ public class GrailsExceptionResolver extends SimpleMappingExceptionResolver impl
         return getRequestLogMessage("Exception", request, null);
     }
 
+    @Override
     public void setServletContext(ServletContext servletContext) {
         this.servletContext = servletContext;
     }
 
+    @Override
     public void setGrailsApplication(GrailsApplication grailsApplication) {
         this.grailsApplication = grailsApplication;
         createStackFilterer();

--- a/grace-web-mvc/src/main/groovy/org/grails/web/errors/GrailsWrappedRuntimeException.java
+++ b/grace-web-mvc/src/main/groovy/org/grails/web/errors/GrailsWrappedRuntimeException.java
@@ -33,6 +33,7 @@ import org.springframework.core.io.Resource;
 import org.springframework.core.io.support.PathMatchingResourcePatternResolver;
 import org.springframework.util.ClassUtils;
 import org.springframework.util.ReflectionUtils;
+import org.springframework.web.context.WebApplicationContext;
 import org.springframework.web.context.support.WebApplicationContextUtils;
 
 import grails.artefact.ArtefactTypes;
@@ -193,15 +194,17 @@ public class GrailsWrappedRuntimeException extends GrailsException {
                     }
                     else {
                         url = this.gspFile;
-                        GrailsApplicationAttributes attrs = null;
                         try {
-                            attrs = grailsApplicationAttributesConstructor.newInstance(servletContext);
+                            WebApplicationContext webApplicationContext = WebApplicationContextUtils.getWebApplicationContext(servletContext);
+                            if (webApplicationContext != null) {
+                                ResourceAwareTemplateEngine engine =
+                                        webApplicationContext.getBean(ResourceAwareTemplateEngine.BEAN_ID, ResourceAwareTemplateEngine.class);
+                                this.lineNumber = engine.mapStackLineNumber(url, this.lineNumber);
+                            }
                         }
                         catch (Exception e) {
                             ReflectionUtils.rethrowRuntimeException(e);
                         }
-                        ResourceAwareTemplateEngine engine = attrs.getPagesTemplateEngine();
-                        this.lineNumber = engine.mapStackLineNumber(url, this.lineNumber);
                     }
                     fileLocation = "grails-app" + urlPrefix + this.fileName;
                 }

--- a/grace-web-taglib/build.gradle
+++ b/grace-web-taglib/build.gradle
@@ -1,8 +1,8 @@
 dependencies {
     compileOnly libs.jakarta.annotation.api
     compileOnlyApi libs.jakarta.servlet
-    api project(":grace-web-common")
     api project(":grace-taglib")
+    api project(":grace-web-common")
 
     testImplementation libs.jakarta.servlet
     testImplementation libs.spring.test

--- a/grace-web/build.gradle
+++ b/grace-web/build.gradle
@@ -3,19 +3,11 @@ dependencies {
     api project(":grace-plugin-api")
     api project(":grace-web-common")
     api project(":grace-web-databinding")
+    api project(":grace-web-gsp")
     api project(":grace-web-mvc")
+    api project(":grace-web-sitemesh")
+    api project(":grace-web-taglib")
     api project(":grace-web-url-mappings")
-
-    api project(":grace-web-gsp"), {
-        exclude group:'org.graceframework', module:'grace-core'
-        exclude group:'org.graceframework', module:'grace-encoder'
-        exclude group:'org.graceframework', module:'grace-web-common'
-    }
-    api project(":grace-web-sitemesh"), {
-        exclude group:'org.graceframework', module:'grace-core'
-        exclude group:'org.graceframework', module:'grace-encoder'
-        exclude group:'org.graceframework', module:'grace-web-common'
-    }
 
     compileOnlyApi libs.jakarta.servlet
     compileOnly libs.grace.datastore.gorm.support


### PR DESCRIPTION
`grace-web-common` should not depends on `grace-gsp`, it used by other modules.

Relocate `ErrorsViewStackTracePrinter` `GrailsWrappedRuntimeException` from `grace-web-common` to `grace-web-mvc`
Remove `getPagesTemplateEngine()` of `GrailsApplicationAttributes`
Update dependencies
  - `grace-web-gsp` no longer depends on `grace-web-taglib`
  - `grace-web-common` no longer depends on `grace-gsp`
  - `grace-plugin-fields` should depends on `grace-web-taglib`