### PR TITLE
Refactor grace-web-url-mappings

### DIFF
--- a/grace-plugin-url-mappings/build.gradle
+++ b/grace-plugin-url-mappings/build.gradle
@@ -2,11 +2,15 @@ dependencies {
     api project(":grace-api")
     api project(":grace-bootstrap")
     api project(":grace-core")
+    compileOnly project(":grace-cli")
     api project(":grace-plugin-controllers")
     api project(":grace-util")
     api project(":grace-web-url-mappings")
 
     compileOnly libs.jakarta.servlet
+    compileOnly libs.jansi
+    compileOnly libs.jline
+
     api libs.spring.boot.autoconfigure
     annotationProcessor libs.spring.boot.autoconfigureProcessor
     annotationProcessor libs.spring.boot.configurationProcessor

--- a/grace-plugin-url-mappings/src/main/groovy/org/grails/web/mapping/reporting/AnsiConsoleUrlMappingsRenderer.groovy
+++ b/grace-plugin-url-mappings/src/main/groovy/org/grails/web/mapping/reporting/AnsiConsoleUrlMappingsRenderer.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2023 the original author or authors.
+ * Copyright 2013-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/grace-plugin-url-mappings/src/main/groovy/org/grails/web/mapping/reporting/UrlMappingsReportCommand.groovy
+++ b/grace-plugin-url-mappings/src/main/groovy/org/grails/web/mapping/reporting/UrlMappingsReportCommand.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2023 the original author or authors.
+ * Copyright 2014-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/grace-plugin-url-mappings/src/main/resources/META-INF/grails.factories
+++ b/grace-plugin-url-mappings/src/main/resources/META-INF/grails.factories
@@ -1,2 +1,5 @@
 grails.core.ArtefactHandler=\
 org.grails.core.artefact.UrlMappingsArtefactHandler
+
+grails.dev.commands.ApplicationCommand=\
+org.grails.web.mapping.reporting.UrlMappingsReportCommand

--- a/grace-web-url-mappings/build.gradle
+++ b/grace-web-url-mappings/build.gradle
@@ -1,6 +1,5 @@
 dependencies {
     api project(":grace-api")
-    api project(":grace-cli")
     api project(":grace-util")
     api project(":grace-web-common")
 
@@ -8,8 +7,6 @@ dependencies {
 
     compileOnlyApi libs.jakarta.servlet
     implementation libs.caffeine
-    compileOnly libs.jansi
-    compileOnly libs.jline
 
     testImplementation libs.jakarta.servlet
     testImplementation project(":grace-test-suite-base")


### PR DESCRIPTION
Relocate `AnsiConsoleUrlMappingsRenderer` `UrlMappingsReportCommand` from grace-web-url-mappings to grace-plugin-url-mappings