### PR TITLE
Refactor GrailsExceptionResolver

### DIFF
--- a/grace-plugin-controllers/build.gradle
+++ b/grace-plugin-controllers/build.gradle
@@ -8,6 +8,7 @@ dependencies {
     api project(":grace-plugin-validation")
     api project(":grace-web-gsp")
     api project(":grace-web-mvc")
+    api project(":grace-web-url-mappings")
     api project(":grace-util")
 
     compileOnly libs.jakarta.servlet

--- a/grace-plugin-controllers/src/main/groovy/org/grails/plugins/web/controllers/ControllersPluginConfiguration.java
+++ b/grace-plugin-controllers/src/main/groovy/org/grails/plugins/web/controllers/ControllersPluginConfiguration.java
@@ -51,6 +51,7 @@ import org.grails.exceptions.reporting.StackTraceFilterer;
 import org.grails.web.errors.GrailsExceptionResolver;
 import org.grails.web.filters.HiddenHttpMethodFilter;
 import org.grails.web.filters.OrderedHiddenHttpMethodFilter;
+import org.grails.web.mapping.mvc.GrailsUrlMappingsExceptionResolver;
 import org.grails.web.servlet.mvc.GrailsDispatcherServlet;
 import org.grails.web.servlet.mvc.GrailsWebRequestFilter;
 import org.grails.web.servlet.mvc.ParameterCreationListener;
@@ -101,7 +102,7 @@ public class ControllersPluginConfiguration {
     @Bean
     public GrailsExceptionResolver exceptionHandler(ObjectProvider<GrailsApplication> grailsApplicationProvider,
             ObjectProvider<StackTraceFilterer> stackTraceFiltererObjectProvider) {
-        GrailsExceptionResolver exceptionResolver = new GrailsExceptionResolver();
+        GrailsUrlMappingsExceptionResolver exceptionResolver = new GrailsUrlMappingsExceptionResolver();
         exceptionResolver.setGrailsApplication(grailsApplicationProvider.getIfAvailable());
         exceptionResolver.setStackTraceFilterer(stackTraceFiltererObjectProvider.getIfAvailable());
 

--- a/grace-test-suite-uber/src/test/groovy/org/grails/web/errors/GrailsExceptionResolverTests.groovy
+++ b/grace-test-suite-uber/src/test/groovy/org/grails/web/errors/GrailsExceptionResolverTests.groovy
@@ -1,34 +1,27 @@
 package org.grails.web.errors
 
-import grails.core.DefaultGrailsApplication
-import grails.core.GrailsApplication
-import grails.util.Environment
-import grails.util.GrailsWebMockUtil
-import grails.web.CamelCaseUrlConverter
-import grails.web.UrlConverter
-import grails.web.mapping.UrlMappingsHolder
-import org.grails.config.PropertySourcesConfig
-import org.grails.exceptions.reporting.DefaultStackTraceFilterer
-import org.grails.plugins.testing.GrailsMockHttpServletRequest
-import org.grails.plugins.testing.GrailsMockHttpServletResponse
-import org.grails.support.MockApplicationContext
-import org.grails.web.mapping.DefaultUrlMappingEvaluator
-import org.grails.web.mapping.DefaultUrlMappingsHolder
-import org.grails.web.servlet.view.CompositeViewResolver
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.springframework.mock.web.MockHttpServletRequest
-import org.springframework.mock.web.MockHttpServletResponse
 import org.springframework.mock.web.MockServletContext
-import org.springframework.web.context.WebApplicationContext
 import org.springframework.web.context.request.RequestContextHolder
-import org.springframework.web.multipart.support.StandardServletMultipartResolver
 import org.springframework.web.servlet.View
 import org.springframework.web.servlet.ViewResolver
 import org.springframework.web.servlet.view.InternalResourceView
 
-import static org.junit.jupiter.api.Assertions.*
+import grails.core.DefaultGrailsApplication
+import grails.core.GrailsApplication
+import grails.util.Environment
+import grails.web.CamelCaseUrlConverter
+import grails.web.UrlConverter
+
+import org.grails.config.PropertySourcesConfig
+import org.grails.exceptions.reporting.DefaultStackTraceFilterer
+import org.grails.support.MockApplicationContext
+
+import static org.junit.jupiter.api.Assertions.assertEquals
+import static org.junit.jupiter.api.Assertions.assertThrows
 
 /**
  * Test case for {@link org.grails.web.errors.GrailsExceptionResolver}.
@@ -36,8 +29,6 @@ import static org.junit.jupiter.api.Assertions.*
 class GrailsExceptionResolverTests {
 
     private application = new DefaultGrailsApplication()
-    private resolver = new GrailsExceptionResolver()
-    private mockContext = new MockServletContext()
     private mockCtx = new MockApplicationContext()
 
     @AfterEach
@@ -49,8 +40,8 @@ class GrailsExceptionResolverTests {
     void setUp() throws Exception {
         mockCtx.registerMockBean(GrailsApplication.APPLICATION_ID, new DefaultGrailsApplication())
         def mainContext = new MockApplicationContext();
-        mainContext.registerMockBean(UrlConverter.BEAN_NAME, new CamelCaseUrlConverter());
-        application.mainContext =  mainContext
+        mainContext.registerMockBean(UrlConverter.BEAN_NAME, new CamelCaseUrlConverter())
+        application.mainContext = mainContext
     }
 
     @Test
@@ -71,101 +62,6 @@ class GrailsExceptionResolverTests {
     }
 
     @Test
-    void testResolveExceptionToView() {
-        def mappings = new DefaultUrlMappingEvaluator(mockCtx).evaluateMappings {
-            "500"(view:"myView")
-        }
-
-        def urlMappingsHolder = new DefaultUrlMappingsHolder(mappings)
-        def webRequest = GrailsWebMockUtil.bindMockWebRequest(mockCtx,
-                new GrailsMockHttpServletRequest(), new GrailsMockHttpServletResponse())
-
-        mockCtx.registerMockBean UrlMappingsHolder.BEAN_ID, urlMappingsHolder
-        ViewResolver viewResolver = new DummyViewResolver()
-        mockCtx.registerMockBean "viewResolver", viewResolver
-        mockCtx.registerMockBean 'grailsApplication', application
-        mockCtx.registerMockBean CompositeViewResolver.BEAN_NAME, new CompositeViewResolver(viewResolvers: [viewResolver])
-        mockContext.setAttribute WebApplicationContext.ROOT_WEB_APPLICATION_CONTEXT_ATTRIBUTE, mockCtx
-
-        resolver.servletContext = mockContext
-        resolver.exceptionMappings = ['java.lang.Exception': '/error'] as Properties
-        resolver.grailsApplication = application
-        resolver.stackFilterer = new DefaultStackTraceFilterer()
-
-        def ex = new Exception()
-        def request = webRequest.currentRequest
-        def response = webRequest.currentResponse
-        def handler = new Object()
-        def modelAndView = resolver.resolveException(request, response, handler, ex)
-
-        assertNotNull modelAndView, "should have returned a ModelAndView"
-        assertEquals "/myView", modelAndView.view.url
-    }
-
-    @Test
-    void testResolveExceptionToController() {
-        def mappings = new DefaultUrlMappingEvaluator(mockCtx).evaluateMappings {
-            "500"(controller:"foo", action:"bar")
-        }
-
-        def urlMappingsHolder = new DefaultUrlMappingsHolder(mappings)
-        def webRequest = GrailsWebMockUtil.bindMockWebRequest()
-
-        mockCtx.registerMockBean UrlMappingsHolder.BEAN_ID, urlMappingsHolder
-        mockCtx.registerMockBean "viewResolver", new DummyViewResolver()
-        mockCtx.registerMockBean GrailsApplication.APPLICATION_ID, application
-        mockCtx.registerMockBean "multipartResolver", new StandardServletMultipartResolver()
-        mockContext.setAttribute WebApplicationContext.ROOT_WEB_APPLICATION_CONTEXT_ATTRIBUTE, mockCtx
-
-        resolver.servletContext = mockContext
-        resolver.exceptionMappings = ['java.lang.Exception': '/error'] as Properties
-        resolver.grailsApplication = application
-        resolver.stackFilterer = new DefaultStackTraceFilterer()
-
-        def ex = new Exception()
-        def request = webRequest.currentRequest
-        MockHttpServletResponse response = webRequest.currentResponse
-        def handler = new Object()
-        def modelAndView = resolver.resolveException(request, response, handler, ex)
-
-        assertNotNull modelAndView, "should have returned a ModelAndView"
-        assertTrue modelAndView.empty
-
-        assertEquals "/foo/bar",response.getForwardedUrl()
-    }
-
-    @Test
-    void testResolveExceptionToControllerWhenResponseCommitted() {
-        def mappings = new DefaultUrlMappingEvaluator(mockCtx).evaluateMappings {
-            "500"(controller:"foo", action:"bar")
-        }
-
-        def urlMappingsHolder = new DefaultUrlMappingsHolder(mappings)
-        def webRequest = GrailsWebMockUtil.bindMockWebRequest()
-
-        mockCtx.registerMockBean UrlMappingsHolder.BEAN_ID, urlMappingsHolder
-        mockCtx.registerMockBean "viewResolver", new DummyViewResolver()
-        mockCtx.registerMockBean GrailsApplication.APPLICATION_ID, application
-        mockCtx.registerMockBean "multipartResolver", new StandardServletMultipartResolver()
-        mockContext.setAttribute WebApplicationContext.ROOT_WEB_APPLICATION_CONTEXT_ATTRIBUTE, mockCtx
-
-        resolver.servletContext = mockContext
-        resolver.exceptionMappings = ['java.lang.Exception': '/error'] as Properties
-        resolver.grailsApplication = application
-        resolver.stackFilterer = new DefaultStackTraceFilterer()
-
-        def ex = new Exception()
-        def request = webRequest.currentRequest
-        MockHttpServletResponse response = webRequest.currentResponse
-        def handler = new Object()
-        response.setCommitted(true)
-        def modelAndView = resolver.resolveException(request, response, handler, ex)
-
-        assertNotNull modelAndView, "should have returned a ModelAndView"
-        assertFalse modelAndView.empty
-    }
-
-    @Test
     void testLogRequestWithException() {
         def config = new ConfigSlurper().parse('''
 grails.exceptionresolver.params.exclude = ['jennysPhoneNumber']
@@ -179,7 +75,7 @@ grails.exceptionresolver.params.exclude = ['jennysPhoneNumber']
         request.addParameter "jennysPhoneNumber", "8675309"
 
         System.setProperty(Environment.KEY, Environment.DEVELOPMENT.name)
-        def resolver = new GrailsExceptionResolver(grailsApplication:new DefaultGrailsApplication(config:new PropertySourcesConfig().merge(config)))
+        def resolver = new GrailsExceptionResolver(grailsApplication: new DefaultGrailsApplication(config: new PropertySourcesConfig().merge(config)))
         resolver.stackFilterer = new DefaultStackTraceFilterer()
         def msg = resolver.getRequestLogMessage(new RuntimeException("bad things happened"), request)
 
@@ -210,7 +106,7 @@ grails.exceptionresolver.params.exclude = ['jennysPhoneNumber']
         request.addParameter "jennysPhoneNumber", "8675309"
 
         System.setProperty(Environment.KEY, Environment.DEVELOPMENT.name)
-        def resolver = new GrailsExceptionResolver(grailsApplication:new DefaultGrailsApplication(config:new PropertySourcesConfig().merge(config)))
+        def resolver = new GrailsExceptionResolver(grailsApplication: new DefaultGrailsApplication(config: new PropertySourcesConfig().merge(config)))
         resolver.stackFilterer = new DefaultStackTraceFilterer()
         def msg = resolver.getRequestLogMessage(request)
 
@@ -251,19 +147,19 @@ Method: GET
 Filtered stacktrace:'''.replaceAll('[\n\r]', '')
 
             System.setProperty(Environment.KEY, Environment.DEVELOPMENT.name)
-            def resolver = new GrailsExceptionResolver(grailsApplication:application)
+            def resolver = new GrailsExceptionResolver(grailsApplication: application)
             resolver.stackFilterer = new DefaultStackTraceFilterer()
             def msg = resolver.getRequestLogMessage(request)
             assertEquals msgWithParameters, msg.replaceAll('[\n\r]', '')
 
             System.setProperty(Environment.KEY, Environment.PRODUCTION.name)
-            resolver = new GrailsExceptionResolver(grailsApplication:application)
+            resolver = new GrailsExceptionResolver(grailsApplication: application)
             resolver.stackFilterer = new DefaultStackTraceFilterer()
             msg = resolver.getRequestLogMessage(request)
             assertEquals msgWithoutParameters, msg.replaceAll('[\n\r]', '')
 
             System.setProperty(Environment.KEY, Environment.TEST.name)
-            resolver = new GrailsExceptionResolver(grailsApplication:application)
+            resolver = new GrailsExceptionResolver(grailsApplication: application)
             resolver.stackFilterer = new DefaultStackTraceFilterer()
             msg = resolver.getRequestLogMessage(request)
             assertEquals msgWithoutParameters, msg.replaceAll('[\n\r]', '')
@@ -273,19 +169,19 @@ grails.exceptionresolver.logRequestParameters = false
 ''')
 
             System.setProperty(Environment.KEY, Environment.DEVELOPMENT.name)
-            resolver = new GrailsExceptionResolver(grailsApplication:new DefaultGrailsApplication(config:new PropertySourcesConfig().merge(config)))
+            resolver = new GrailsExceptionResolver(grailsApplication: new DefaultGrailsApplication(config: new PropertySourcesConfig().merge(config)))
             resolver.stackFilterer = new DefaultStackTraceFilterer()
             msg = resolver.getRequestLogMessage(request)
             assertEquals msgWithoutParameters, msg.replaceAll('[\n\r]', '')
 
             System.setProperty(Environment.KEY, Environment.PRODUCTION.name)
-            resolver = new GrailsExceptionResolver(grailsApplication:new DefaultGrailsApplication(config:new PropertySourcesConfig().merge(config)))
+            resolver = new GrailsExceptionResolver(grailsApplication: new DefaultGrailsApplication(config: new PropertySourcesConfig().merge(config)))
             resolver.stackFilterer = new DefaultStackTraceFilterer()
             msg = resolver.getRequestLogMessage(request)
             assertEquals msgWithoutParameters, msg.replaceAll('[\n\r]', '')
 
             System.setProperty(Environment.KEY, Environment.TEST.name)
-            resolver = new GrailsExceptionResolver(grailsApplication:new DefaultGrailsApplication(config:new PropertySourcesConfig().merge(config)))
+            resolver = new GrailsExceptionResolver(grailsApplication: new DefaultGrailsApplication(config: new PropertySourcesConfig().merge(config)))
             resolver.stackFilterer = new DefaultStackTraceFilterer()
             msg = resolver.getRequestLogMessage(request)
             assertEquals msgWithoutParameters, msg.replaceAll('[\n\r]', '')
@@ -295,30 +191,34 @@ grails.exceptionresolver.logRequestParameters = true
 ''')
 
             System.setProperty(Environment.KEY, Environment.DEVELOPMENT.name)
-            resolver = new GrailsExceptionResolver(grailsApplication:new DefaultGrailsApplication(config:new PropertySourcesConfig().merge(config)))
+            resolver = new GrailsExceptionResolver(grailsApplication: new DefaultGrailsApplication(config: new PropertySourcesConfig().merge(config)))
             resolver.stackFilterer = new DefaultStackTraceFilterer()
             msg = resolver.getRequestLogMessage(request)
             assertEquals msgWithParameters, msg.replaceAll('[\n\r]', '')
 
             System.setProperty(Environment.KEY, Environment.PRODUCTION.name)
-            resolver = new GrailsExceptionResolver(grailsApplication:new DefaultGrailsApplication(config:new PropertySourcesConfig().merge(config)))
+            resolver = new GrailsExceptionResolver(grailsApplication: new DefaultGrailsApplication(config: new PropertySourcesConfig().merge(config)))
             resolver.stackFilterer = new DefaultStackTraceFilterer()
             msg = resolver.getRequestLogMessage(request)
             assertEquals msgWithParameters, msg.replaceAll('[\n\r]', '')
 
             System.setProperty(Environment.KEY, Environment.TEST.name)
-            resolver = new GrailsExceptionResolver(grailsApplication:new DefaultGrailsApplication(config:new PropertySourcesConfig().merge(config)))
+            resolver = new GrailsExceptionResolver(grailsApplication: new DefaultGrailsApplication(config: new PropertySourcesConfig().merge(config)))
             resolver.stackFilterer = new DefaultStackTraceFilterer()
             msg = resolver.getRequestLogMessage(request)
             assertEquals msgWithParameters, msg.replaceAll('[\n\r]', '')
-        } finally {
+        }
+        finally {
             System.setProperty(Environment.KEY, oldEnvName)
         }
     }
 }
 
 class DummyViewResolver implements ViewResolver {
+
+    @Override
     View resolveViewName(String viewName, Locale locale) {
         new InternalResourceView(viewName)
     }
+
 }

--- a/grace-web-mvc/build.gradle
+++ b/grace-web-mvc/build.gradle
@@ -1,7 +1,6 @@
 dependencies {
     api project(":grace-gsp")
     api project(":grace-web")
-    api project(":grace-web-url-mappings")
 
     compileOnlyApi libs.jakarta.servlet
 

--- a/grace-web-mvc/src/main/groovy/org/grails/web/errors/GrailsExceptionResolver.java
+++ b/grace-web-mvc/src/main/groovy/org/grails/web/errors/GrailsExceptionResolver.java
@@ -63,6 +63,7 @@ public class GrailsExceptionResolver extends SimpleMappingExceptionResolver impl
     @Override
     public ModelAndView resolveException(HttpServletRequest request, HttpServletResponse response, Object handler, Exception ex) {
         // don't reuse cached controller attribute
+        request.removeAttribute(GrailsApplicationAttributes.CONTROLLER);
         request.removeAttribute(GrailsApplicationAttributes.GRAILS_CONTROLLER_CLASS_AVAILABLE);
 
         ex = findWrappedException(ex);
@@ -127,6 +128,7 @@ public class GrailsExceptionResolver extends SimpleMappingExceptionResolver impl
         GrailsWrappedRuntimeException gwre = new GrailsWrappedRuntimeException(this.servletContext, e);
         mv.addObject(WebUtils.ERROR_EXCEPTION_ATTRIBUTE, gwre);
         mv.addObject(WebUtils.EXCEPTION_ATTRIBUTE, gwre);
+        mv.setStatus(HttpStatusCode.valueOf(HttpServletResponse.SC_INTERNAL_SERVER_ERROR));
     }
 
     protected void logStackTrace(Exception e, HttpServletRequest request) {

--- a/grace-web-mvc/src/main/groovy/org/grails/web/errors/GrailsExceptionResolver.java
+++ b/grace-web-mvc/src/main/groovy/org/grails/web/errors/GrailsExceptionResolver.java
@@ -15,24 +15,19 @@
  */
 package org.grails.web.errors;
 
-import java.io.IOException;
 import java.util.Collections;
 import java.util.Enumeration;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
 import jakarta.servlet.ServletContext;
-import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 
 import org.codehaus.groovy.control.CompilationFailedException;
 import org.codehaus.groovy.runtime.InvokerInvocationException;
+import org.springframework.http.HttpStatusCode;
 import org.springframework.web.context.ServletContextAware;
 import org.springframework.web.servlet.ModelAndView;
-import org.springframework.web.servlet.View;
-import org.springframework.web.servlet.ViewResolver;
 import org.springframework.web.servlet.handler.SimpleMappingExceptionResolver;
 
 import grails.config.Config;
@@ -40,15 +35,8 @@ import grails.config.Settings;
 import grails.core.GrailsApplication;
 import grails.core.support.GrailsApplicationAware;
 import grails.util.Environment;
-import grails.web.mapping.UrlMappingInfo;
-import grails.web.mapping.UrlMappingsHolder;
-import grails.web.mapping.exceptions.UrlMappingException;
-
-import org.grails.core.exceptions.GrailsRuntimeException;
 import org.grails.exceptions.ExceptionUtils;
 import org.grails.exceptions.reporting.StackTraceFilterer;
-import org.grails.web.mapping.DefaultUrlMappingInfo;
-import org.grails.web.mapping.UrlMappingUtils;
 import org.grails.web.servlet.mvc.exceptions.GrailsMVCException;
 import org.grails.web.util.GrailsApplicationAttributes;
 import org.grails.web.util.WebUtils;
@@ -59,7 +47,7 @@ import org.grails.web.util.WebUtils;
  * @author Graeme Rocher
  * @author Michael Yan
  */
-@SuppressWarnings({ "rawtypes", "unchecked" })
+@SuppressWarnings({ "unchecked" })
 public class GrailsExceptionResolver extends SimpleMappingExceptionResolver implements ServletContextAware, GrailsApplicationAware {
 
     public static final String EXCEPTION_ATTRIBUTE = WebUtils.EXCEPTION_ATTRIBUTE;
@@ -87,11 +75,6 @@ public class GrailsExceptionResolver extends SimpleMappingExceptionResolver impl
 
         logStackTrace(ex, request);
 
-        UrlMappingsHolder urlMappings = lookupUrlMappings();
-        if (urlMappings != null) {
-            mv = resolveViewOrForward(ex, urlMappings, request, response, mv);
-        }
-
         return mv;
     }
 
@@ -117,6 +100,7 @@ public class GrailsExceptionResolver extends SimpleMappingExceptionResolver impl
 
     /**
      * Obtains the root cause of the given exception
+     *
      * @param ex The exception
      * @return The root cause
      */
@@ -143,106 +127,6 @@ public class GrailsExceptionResolver extends SimpleMappingExceptionResolver impl
         GrailsWrappedRuntimeException gwre = new GrailsWrappedRuntimeException(this.servletContext, e);
         mv.addObject(WebUtils.ERROR_EXCEPTION_ATTRIBUTE, gwre);
         mv.addObject(WebUtils.EXCEPTION_ATTRIBUTE, gwre);
-    }
-
-    protected UrlMappingsHolder lookupUrlMappings() {
-        try {
-            return UrlMappingUtils.lookupUrlMappings(this.servletContext);
-        }
-        catch (Exception ignored) {
-            // ignore, no app ctx in this case.
-            return null;
-        }
-    }
-
-    Map extractRequestParamsWithUrlMappingHolder(UrlMappingsHolder urlMappings, HttpServletRequest request) {
-        Map params = new HashMap();
-        try {
-            UrlMappingInfo requestInfo = urlMappings.match(request.getRequestURI());
-            if (requestInfo != null) {
-                params.putAll(UrlMappingUtils.findAllParamsNotInUrlMappingKeywords(requestInfo.getParameters()));
-            }
-        }
-        catch (UrlMappingException ulrMappingException) {
-            logger.debug("Could not find urlMapping which matches: " + request.getRequestURI());
-        }
-        return params;
-    }
-
-    protected ModelAndView resolveViewOrForward(Exception ex, UrlMappingsHolder urlMappings, HttpServletRequest request,
-            HttpServletResponse response, ModelAndView mv) {
-
-        UrlMappingInfo info = matchStatusCode(ex, urlMappings);
-
-        if (info != null) {
-            Map params = extractRequestParamsWithUrlMappingHolder(urlMappings, request);
-            if (params != null && !params.isEmpty()) {
-                Map infoParams = info.getParameters();
-                if (infoParams != null) {
-                    params.putAll(info.getParameters());
-                }
-                info = new DefaultUrlMappingInfo(info, params, this.grailsApplication);
-            }
-        }
-
-        try {
-            if (info != null && info.getViewName() != null) {
-                resolveView(request, info, mv);
-            }
-            else if (info != null && info.getControllerName() != null) {
-                String uri = determineUri(request);
-                if (!response.isCommitted()) {
-                    forwardRequest(info, request, response, mv, uri);
-                    // return an empty ModelAndView since the error handler has been processed
-                    return new ModelAndView();
-                }
-            }
-            return mv;
-        }
-        catch (Exception e) {
-            logger.error("Unable to render errors view: " + e.getMessage(), e);
-            throw new GrailsRuntimeException(e);
-        }
-    }
-
-    protected void forwardRequest(UrlMappingInfo info, HttpServletRequest request, HttpServletResponse response,
-            ModelAndView mv, String uri) throws ServletException, IOException {
-
-        info.configure(WebUtils.retrieveGrailsWebRequest());
-        String forwardUrl = UrlMappingUtils.forwardRequestForUrlMappingInfo(
-                request, response, info, mv.getModel(), true);
-        if (logger.isDebugEnabled()) {
-            logger.debug("Matched URI [" + uri + "] to URL mapping [" + info +
-                    "], forwarding to [" + forwardUrl + "] with response [" + response.getClass() + "]");
-        }
-    }
-
-    protected String determineUri(HttpServletRequest request) {
-        String uri = (String) request.getAttribute(WebUtils.FORWARD_REQUEST_URI_ATTRIBUTE);
-        if (uri == null) {
-            uri = request.getRequestURI();
-        }
-        return uri;
-    }
-
-    protected void resolveView(HttpServletRequest request, UrlMappingInfo info, ModelAndView mv) throws Exception {
-        ViewResolver viewResolver = WebUtils.lookupViewResolver(this.servletContext);
-        View v = UrlMappingUtils.resolveView(request, info, info.getViewName(), viewResolver);
-        if (v != null) {
-            mv.setView(v);
-        }
-    }
-
-    protected UrlMappingInfo matchStatusCode(Exception ex, UrlMappingsHolder urlMappings) {
-        UrlMappingInfo info = urlMappings.matchStatusCode(HttpServletResponse.SC_INTERNAL_SERVER_ERROR, ex);
-        if (info == null) {
-            info = urlMappings.matchStatusCode(HttpServletResponse.SC_INTERNAL_SERVER_ERROR,
-                    getRootCause(ex));
-        }
-        if (info == null) {
-            info = urlMappings.matchStatusCode(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
-        }
-        return info;
     }
 
     protected void logStackTrace(Exception e, HttpServletRequest request) {

--- a/grace-web-mvc/src/main/groovy/org/grails/web/errors/GrailsWrappedRuntimeException.java
+++ b/grace-web-mvc/src/main/groovy/org/grails/web/errors/GrailsWrappedRuntimeException.java
@@ -15,41 +15,12 @@
  */
 package org.grails.web.errors;
 
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.io.LineNumberReader;
-import java.lang.reflect.Constructor;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-
 import jakarta.servlet.ServletContext;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
-import org.codehaus.groovy.control.MultipleCompilationErrorsException;
-import org.codehaus.groovy.control.messages.SyntaxErrorMessage;
-import org.springframework.core.io.Resource;
-import org.springframework.core.io.support.PathMatchingResourcePatternResolver;
-import org.springframework.util.ClassUtils;
-import org.springframework.util.ReflectionUtils;
-import org.springframework.web.context.WebApplicationContext;
-import org.springframework.web.context.support.WebApplicationContextUtils;
-
-import grails.artefact.ArtefactTypes;
-import grails.core.GrailsApplication;
-import grails.util.GrailsStringUtils;
-
-import org.grails.buffer.FastStringPrintWriter;
 import org.grails.core.exceptions.GrailsException;
-import org.grails.exceptions.reporting.SourceCodeAware;
-import org.grails.gsp.ResourceAwareTemplateEngine;
-import org.grails.io.support.GrailsFactoriesLoader;
-import org.grails.web.servlet.mvc.GrailsWebRequest;
-import org.grails.web.util.GrailsApplicationAttributes;
 
 /**
- * Wraps a Grails RuntimeException and attempts to extract more relevent diagnostic messages
+ * Wraps a Grails RuntimeException and attempts to extract more relevant diagnostic messages
  * from the stack trace.
  *
  * @author Graeme Rocher
@@ -58,45 +29,9 @@ import org.grails.web.util.GrailsApplicationAttributes;
  */
 public class GrailsWrappedRuntimeException extends GrailsException {
 
-    public static final String URL_PREFIX = "/WEB-INF/grails-app/";
-
-    private static final Log logger = LogFactory.getLog(GrailsWrappedRuntimeException.class);
-
-    private static final Class<? extends GrailsApplicationAttributes> grailsApplicationAttributesClass = GrailsFactoriesLoader.loadFactoryClasses(
-            GrailsApplicationAttributes.class, GrailsWebRequest.class.getClassLoader()).get(0);
-
-    private static final Constructor<? extends GrailsApplicationAttributes> grailsApplicationAttributesConstructor =
-            ClassUtils.getConstructorIfAvailable(grailsApplicationAttributesClass, ServletContext.class);
-
     private static final long serialVersionUID = 7284065617154554366L;
 
-    private static final Pattern ANY_GSP_DETAILS = Pattern.compile("_gsp.run");
-
-    private static final Pattern PARSE_DETAILS_STEP1 = Pattern.compile("\\((\\w+)\\.groovy:(\\d+)\\)");
-
-    private static final Pattern PARSE_DETAILS_STEP2 = Pattern.compile("at\\s{1}(\\w+)\\$_closure\\d+\\.doCall\\(\\1:(\\d+)\\)");
-
-    private static final Pattern PARSE_GSP_DETAILS_STEP1 = Pattern.compile("_gsp\\.run\\(((\\w+?)_.*?):(\\d+)\\)");
-
-    private final PathMatchingResourcePatternResolver resolver = new PathMatchingResourcePatternResolver();
-
-    private static final String UNKNOWN = "Unknown";
-
-    private String className = UNKNOWN;
-
-    private int lineNumber = -1;
-
     private final Throwable cause;
-
-    private final String stackTrace;
-
-    private final String[] stackTraceLines;
-
-    private String[] codeSnippet = new String[0];
-
-    private String gspFile;
-
-    private String fileName;
 
     /**
      * @param servletContext The ServletContext instance
@@ -105,227 +40,13 @@ public class GrailsWrappedRuntimeException extends GrailsException {
     public GrailsWrappedRuntimeException(ServletContext servletContext, Throwable t) {
         super(t.getMessage(), t);
         this.cause = t;
-        Throwable cause = t;
-
-        FastStringPrintWriter pw = FastStringPrintWriter.newInstance();
-        cause.printStackTrace(pw);
-        this.stackTrace = pw.toString();
-
-        while (cause.getCause() != cause) {
-            if (cause.getCause() == null) {
-                break;
-            }
-            cause = cause.getCause();
-        }
-
-        this.stackTraceLines = this.stackTrace.split("\\n");
-
-        if (cause instanceof MultipleCompilationErrorsException) {
-            MultipleCompilationErrorsException mcee = (MultipleCompilationErrorsException) cause;
-            Object message = mcee.getErrorCollector().getErrors().iterator().next();
-            if (message instanceof SyntaxErrorMessage) {
-                SyntaxErrorMessage sem = (SyntaxErrorMessage) message;
-                this.lineNumber = sem.getCause().getLine();
-                this.className = sem.getCause().getSourceLocator();
-                sem.write(pw);
-            }
-        }
-        else {
-            Matcher m1 = PARSE_DETAILS_STEP1.matcher(this.stackTrace);
-            Matcher m2 = PARSE_DETAILS_STEP2.matcher(this.stackTrace);
-            Matcher gsp = PARSE_GSP_DETAILS_STEP1.matcher(this.stackTrace);
-            try {
-                if (ANY_GSP_DETAILS.matcher(this.stackTrace).find() && gsp.find()) {
-                    System.out.println(gsp.group(1) + " " + gsp.group(2) + " " + gsp.group(3));
-                    this.className = gsp.group(1);
-                    this.lineNumber = Integer.parseInt(gsp.group(3));
-                    this.gspFile = URL_PREFIX + "views/" + gsp.group(2) + '/' + this.className;
-                }
-                else {
-                    if (m1.find()) {
-                        do {
-                            this.className = m1.group(1);
-                            this.lineNumber = Integer.parseInt(m1.group(2));
-                        }
-                        while (m1.find());
-                    }
-                    else {
-                        while (m2.find()) {
-                            this.className = m2.group(1);
-                            this.lineNumber = Integer.parseInt(m2.group(2));
-                        }
-                    }
-                }
-            }
-            catch (NumberFormatException ignored) {
-            }
-        }
-
-        LineNumberReader reader = null;
-        try {
-            checkIfSourceCodeAware(t);
-            checkIfSourceCodeAware(cause);
-
-            if (getLineNumber() > -1) {
-                String fileLocation;
-                String url = null;
-
-                if (this.fileName != null) {
-                    fileLocation = this.fileName;
-                }
-                else {
-                    String urlPrefix = "";
-                    if (this.gspFile == null) {
-                        this.fileName = this.className.replace('.', '/') + ".groovy";
-
-                        GrailsApplication application = WebApplicationContextUtils.getRequiredWebApplicationContext(servletContext)
-                                .getBean(GrailsApplication.APPLICATION_ID, GrailsApplication.class);
-                        // @todo Refactor this to get the urlPrefix from the ArtefactHandler
-                        if (application.isArtefactOfType(ArtefactTypes.CONTROLLER, this.className)) {
-                            urlPrefix += "/controllers/";
-                        }
-                        else if (application.isArtefactOfType("TagLib", this.className)) {
-                            urlPrefix += "/taglib/";
-                        }
-                        else if (application.isArtefactOfType(ArtefactTypes.SERVICE, this.className)) {
-                            urlPrefix += "/services/";
-                        }
-                        url = URL_PREFIX + urlPrefix + this.fileName;
-                    }
-                    else {
-                        url = this.gspFile;
-                        try {
-                            WebApplicationContext webApplicationContext = WebApplicationContextUtils.getWebApplicationContext(servletContext);
-                            if (webApplicationContext != null) {
-                                ResourceAwareTemplateEngine engine =
-                                        webApplicationContext.getBean(ResourceAwareTemplateEngine.BEAN_ID, ResourceAwareTemplateEngine.class);
-                                this.lineNumber = engine.mapStackLineNumber(url, this.lineNumber);
-                            }
-                        }
-                        catch (Exception e) {
-                            ReflectionUtils.rethrowRuntimeException(e);
-                        }
-                    }
-                    fileLocation = "grails-app" + urlPrefix + this.fileName;
-                }
-
-                InputStream in = null;
-                if (!GrailsStringUtils.isBlank(url)) {
-                    in = servletContext.getResourceAsStream(url);
-                    logger.debug("Attempting to display code snippet found in url " + url);
-                }
-                if (in == null) {
-                    Resource r = null;
-                    try {
-                        r = this.resolver.getResource(fileLocation);
-                        in = r.getInputStream();
-                    }
-                    catch (Throwable e) {
-                        r = this.resolver.getResource("file:" + fileLocation);
-                        if (r.exists()) {
-                            try {
-                                in = r.getInputStream();
-                            }
-                            catch (IOException ignored) {
-                            }
-                        }
-                    }
-                }
-
-                if (in != null) {
-                    reader = new LineNumberReader(new InputStreamReader(in, "UTF-8"));
-                    String currentLine = reader.readLine();
-                    StringBuilder buf = new StringBuilder();
-                    while (currentLine != null) {
-                        int currentLineNumber = reader.getLineNumber();
-                        if ((this.lineNumber > 0 && currentLineNumber == this.lineNumber - 1) ||
-                                (currentLineNumber == this.lineNumber)) {
-                            buf.append(currentLineNumber)
-                                    .append(": ")
-                                    .append(currentLine)
-                                    .append("\n");
-                        }
-                        else if (currentLineNumber == this.lineNumber + 1) {
-                            buf.append(currentLineNumber)
-                                    .append(": ")
-                                    .append(currentLine);
-                            break;
-                        }
-                        currentLine = reader.readLine();
-                    }
-                    this.codeSnippet = buf.toString().split("\n");
-                }
-            }
-        }
-        catch (IOException e) {
-            logger.warn("[GrailsWrappedRuntimeException] I/O error reading line diagnostics: " + e.getMessage(), e);
-        }
-        finally {
-            if (reader != null) {
-                try {
-                    reader.close();
-                }
-                catch (IOException ignored) {
-                }
-            }
-        }
     }
 
-    private void checkIfSourceCodeAware(Throwable t) {
-        if (!(t instanceof SourceCodeAware)) {
-            return;
-        }
-
-        SourceCodeAware codeAware = (SourceCodeAware) t;
-        if (codeAware.getFileName() != null) {
-            this.fileName = codeAware.getFileName();
-            if (this.className == null || UNKNOWN.equals(this.className)) {
-                this.className = codeAware.getFileName();
-            }
-        }
-        if (codeAware.getLineNumber() > -1) {
-            this.lineNumber = codeAware.getLineNumber();
-        }
+    @Override
+    public Throwable getCause() {
+        return this.cause;
     }
 
-    /**
-     * @return Returns the line.
-     */
-    public String[] getCodeSnippet() {
-        return this.codeSnippet;
-    }
-
-    /**
-     * @return Returns the className.
-     */
-    public String getClassName() {
-        return this.className;
-    }
-
-    /**
-     * @return Returns the lineNumber.
-     */
-    public int getLineNumber() {
-        return this.lineNumber;
-    }
-
-    /**
-     * @return Returns the stackTrace.
-     */
-    public String getStackTraceText() {
-        return this.stackTrace;
-    }
-
-    /**
-     * @return Returns the stackTrace lines
-     */
-    public String[] getStackTraceLines() {
-        return this.stackTraceLines;
-    }
-
-    /* (non-Javadoc)
-     * @see groovy.lang.GroovyRuntimeException#getMessage()
-     */
     @Override
     public String getMessage() {
         return this.cause.getMessage();

--- a/grace-web-mvc/src/test/groovy/org/grails/web/errors/GrailsExceptionResolverSpec.groovy
+++ b/grace-web-mvc/src/test/groovy/org/grails/web/errors/GrailsExceptionResolverSpec.groovy
@@ -1,28 +1,35 @@
 package org.grails.web.errors
 
-import grails.web.mapping.UrlMappingsHolder
-import grails.web.mapping.exceptions.UrlMappingException
+import jakarta.servlet.http.HttpServletResponse
+import jakarta.servlet.http.HttpServletRequest
+
+import org.apache.groovy.util.Maps
 import org.springframework.mock.web.MockHttpServletRequest
+import org.springframework.mock.web.MockHttpServletResponse
+import org.springframework.validation.SimpleErrors
+import org.springframework.web.servlet.ModelAndView
 import spock.lang.Specification
 
-import jakarta.servlet.http.HttpServletRequest
+import grails.validation.ValidationException
+
+import org.grails.exceptions.reporting.DefaultStackTraceFilterer
 
 class GrailsExceptionResolverSpec extends Specification {
 
-    def "exception not thrown if an UrlMappingException is thrown while trying to match a request uri with a UrlMappingInfo "() {
+    def "The viewName will be '/error' if throw a ValidationException"() {
         given:
-        GrailsExceptionResolver grailsExceptionResolver = new GrailsExceptionResolver()
+        HttpServletRequest request = new MockHttpServletRequest()
+        HttpServletResponse response = new MockHttpServletResponse()
+        GrailsExceptionResolver exceptionResolver = new GrailsExceptionResolver()
+        exceptionResolver.stackFilterer = new DefaultStackTraceFilterer()
+        exceptionResolver.setExceptionMappings(Maps.of('java.lang.Exception', '/error') as Properties)
 
         when:
-        def urlMappingsHolder = Mock(UrlMappingsHolder)
-        urlMappingsHolder.match(_ as String) >> { String uri ->
-            throw new UrlMappingException('Unable to establish controller name to dispatch for')
-        }
-        HttpServletRequest request = new MockHttpServletRequest()
-        Map params = grailsExceptionResolver.extractRequestParamsWithUrlMappingHolder(urlMappingsHolder, request)
+        ValidationException validationException = new ValidationException('Validation Exception', new SimpleErrors('This is a simple error'))
+        ModelAndView modelAndView = exceptionResolver.resolveException(request, response, null, validationException)
 
         then:
-        noExceptionThrown()
-        params.isEmpty()
+        modelAndView.viewName == '/error'
     }
+
 }

--- a/grace-web-mvc/src/test/groovy/org/grails/web/errors/GrailsExceptionResolverSpec.groovy
+++ b/grace-web-mvc/src/test/groovy/org/grails/web/errors/GrailsExceptionResolverSpec.groovy
@@ -4,6 +4,7 @@ import jakarta.servlet.http.HttpServletResponse
 import jakarta.servlet.http.HttpServletRequest
 
 import org.apache.groovy.util.Maps
+import org.springframework.http.HttpStatusCode
 import org.springframework.mock.web.MockHttpServletRequest
 import org.springframework.mock.web.MockHttpServletResponse
 import org.springframework.validation.SimpleErrors
@@ -30,6 +31,7 @@ class GrailsExceptionResolverSpec extends Specification {
 
         then:
         modelAndView.viewName == '/error'
+        modelAndView.status == HttpStatusCode.valueOf(500)
     }
 
 }

--- a/grace-web-url-mappings/build.gradle
+++ b/grace-web-url-mappings/build.gradle
@@ -2,6 +2,7 @@ dependencies {
     api project(":grace-api")
     api project(":grace-util")
     api project(":grace-web")
+    api project(":grace-web-mvc")
 
     api(libs.grace.datastore.gorm.validation)
 

--- a/grace-web-url-mappings/src/main/groovy/org/grails/web/mapping/mvc/GrailsUrlMappingsExceptionResolver.java
+++ b/grace-web-url-mappings/src/main/groovy/org/grails/web/mapping/mvc/GrailsUrlMappingsExceptionResolver.java
@@ -1,0 +1,162 @@
+/*
+ * Copyright 2022-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.grails.web.mapping.mvc;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import org.springframework.web.servlet.ModelAndView;
+import org.springframework.web.servlet.View;
+import org.springframework.web.servlet.ViewResolver;
+
+import grails.web.mapping.UrlMappingInfo;
+import grails.web.mapping.UrlMappingsHolder;
+import grails.web.mapping.exceptions.UrlMappingException;
+
+import org.grails.core.exceptions.GrailsRuntimeException;
+import org.grails.web.errors.GrailsExceptionResolver;
+import org.grails.web.mapping.DefaultUrlMappingInfo;
+import org.grails.web.mapping.UrlMappingUtils;
+import org.grails.web.util.WebUtils;
+
+/**
+ * {@link org.springframework.web.servlet.HandlerExceptionResolver} implementation
+ * that allows for mapping exception class names to view names, either for a set of
+ * given url mappings.
+ *
+ * @author Michael Yan
+ * @since 2024.0.0
+ */
+@SuppressWarnings({ "rawtypes", "unchecked" })
+public class GrailsUrlMappingsExceptionResolver extends GrailsExceptionResolver {
+
+    @Override
+    public ModelAndView resolveException(HttpServletRequest request, HttpServletResponse response, Object handler, Exception ex) {
+        ModelAndView mv = super.resolveException(request, response, handler, ex);
+
+        UrlMappingsHolder urlMappings = lookupUrlMappings();
+        if (urlMappings != null) {
+            mv = resolveViewOrForward(ex, urlMappings, request, response, mv);
+        }
+
+        return mv;
+    }
+
+    protected UrlMappingsHolder lookupUrlMappings() {
+        try {
+            return UrlMappingUtils.lookupUrlMappings(this.servletContext);
+        }
+        catch (Exception ignored) {
+            // ignore, no app ctx in this case.
+            return null;
+        }
+    }
+
+    Map extractRequestParamsWithUrlMappingHolder(UrlMappingsHolder urlMappings, HttpServletRequest request) {
+        Map params = new HashMap();
+        try {
+            UrlMappingInfo requestInfo = urlMappings.match(request.getRequestURI());
+            if (requestInfo != null) {
+                params.putAll(UrlMappingUtils.findAllParamsNotInUrlMappingKeywords(requestInfo.getParameters()));
+            }
+        }
+        catch (UrlMappingException ulrMappingException) {
+            logger.debug("Could not find urlMapping which matches: " + request.getRequestURI());
+        }
+        return params;
+    }
+
+    protected ModelAndView resolveViewOrForward(Exception ex, UrlMappingsHolder urlMappings, HttpServletRequest request,
+            HttpServletResponse response, ModelAndView mv) {
+        UrlMappingInfo info = matchStatusCode(ex, urlMappings);
+
+        if (info != null) {
+            Map params = extractRequestParamsWithUrlMappingHolder(urlMappings, request);
+            if (params != null && !params.isEmpty()) {
+                Map infoParams = info.getParameters();
+                if (infoParams != null) {
+                    params.putAll(info.getParameters());
+                }
+                info = new DefaultUrlMappingInfo(info, params, this.grailsApplication);
+            }
+        }
+
+        try {
+            if (info != null && info.getViewName() != null) {
+                resolveView(request, info, mv);
+            }
+            else if (info != null && info.getControllerName() != null) {
+                String uri = determineUri(request);
+                if (!response.isCommitted()) {
+                    forwardRequest(info, request, response, mv, uri);
+                    // return an empty ModelAndView since the error handler has been processed
+                    return new ModelAndView();
+                }
+            }
+            return mv;
+        }
+        catch (Exception e) {
+            logger.error("Unable to render errors view: " + e.getMessage(), e);
+            throw new GrailsRuntimeException(e);
+        }
+    }
+
+    protected void forwardRequest(UrlMappingInfo info, HttpServletRequest request, HttpServletResponse response,
+            ModelAndView mv, String uri) throws ServletException, IOException {
+
+        info.configure(WebUtils.retrieveGrailsWebRequest());
+        String forwardUrl = UrlMappingUtils.forwardRequestForUrlMappingInfo(
+                request, response, info, mv.getModel(), true);
+        if (logger.isDebugEnabled()) {
+            logger.debug("Matched URI [" + uri + "] to URL mapping [" + info +
+                    "], forwarding to [" + forwardUrl + "] with response [" + response.getClass() + "]");
+        }
+    }
+
+    protected String determineUri(HttpServletRequest request) {
+        String uri = (String) request.getAttribute(WebUtils.FORWARD_REQUEST_URI_ATTRIBUTE);
+        if (uri == null) {
+            uri = request.getRequestURI();
+        }
+        return uri;
+    }
+
+    protected void resolveView(HttpServletRequest request, UrlMappingInfo info, ModelAndView mv) throws Exception {
+        ViewResolver viewResolver = WebUtils.lookupViewResolver(this.servletContext);
+        View v = UrlMappingUtils.resolveView(request, info, info.getViewName(), viewResolver);
+        if (v != null) {
+            mv.setView(v);
+        }
+    }
+
+    protected UrlMappingInfo matchStatusCode(Exception ex, UrlMappingsHolder urlMappings) {
+        UrlMappingInfo info = urlMappings.matchStatusCode(HttpServletResponse.SC_INTERNAL_SERVER_ERROR, ex);
+        if (info == null) {
+            info = urlMappings.matchStatusCode(HttpServletResponse.SC_INTERNAL_SERVER_ERROR,
+                    getRootCause(ex));
+        }
+        if (info == null) {
+            info = urlMappings.matchStatusCode(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
+        }
+        return info;
+    }
+
+}

--- a/grace-web-url-mappings/src/test/groovy/org/grails/web/mapping/mvc/GrailsUrlMappingsExceptionResolverSpec.groovy
+++ b/grace-web-url-mappings/src/test/groovy/org/grails/web/mapping/mvc/GrailsUrlMappingsExceptionResolverSpec.groovy
@@ -1,0 +1,28 @@
+package org.grails.web.mapping.mvc
+
+import grails.web.mapping.UrlMappingsHolder
+import grails.web.mapping.exceptions.UrlMappingException
+import org.springframework.mock.web.MockHttpServletRequest
+import spock.lang.Specification
+
+import jakarta.servlet.http.HttpServletRequest
+
+class GrailsUrlMappingsExceptionResolverSpec extends Specification {
+
+    def "exception not thrown if an UrlMappingException is thrown while trying to match a request uri with a UrlMappingInfo "() {
+        given:
+        GrailsUrlMappingsExceptionResolver urlMappingsExceptionResolver = new GrailsUrlMappingsExceptionResolver()
+
+        when:
+        def urlMappingsHolder = Mock(UrlMappingsHolder)
+        urlMappingsHolder.match(_ as String) >> { String uri ->
+            throw new UrlMappingException('Unable to establish controller name to dispatch for')
+        }
+        HttpServletRequest request = new MockHttpServletRequest()
+        Map params = urlMappingsExceptionResolver.extractRequestParamsWithUrlMappingHolder(urlMappingsHolder, request)
+
+        then:
+        noExceptionThrown()
+        params.isEmpty()
+    }
+}

--- a/grace-web-url-mappings/src/test/groovy/org/grails/web/mapping/mvc/GrailsUrlMappingsExceptionResolverTests.groovy
+++ b/grace-web-url-mappings/src/test/groovy/org/grails/web/mapping/mvc/GrailsUrlMappingsExceptionResolverTests.groovy
@@ -1,0 +1,342 @@
+package org.grails.web.mapping.mvc
+
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.mock.web.MockHttpServletRequest
+import org.springframework.mock.web.MockHttpServletResponse
+import org.springframework.mock.web.MockServletContext
+import org.springframework.web.context.WebApplicationContext
+import org.springframework.web.context.request.RequestContextHolder
+import org.springframework.web.multipart.support.StandardServletMultipartResolver
+import org.springframework.web.servlet.View
+import org.springframework.web.servlet.ViewResolver
+import org.springframework.web.servlet.view.InternalResourceView
+
+import grails.core.DefaultGrailsApplication
+import grails.core.GrailsApplication
+import grails.util.Environment
+import grails.util.GrailsWebMockUtil
+import grails.web.CamelCaseUrlConverter
+import grails.web.UrlConverter
+import grails.web.mapping.UrlMappingsHolder
+
+import org.grails.config.PropertySourcesConfig
+import org.grails.exceptions.reporting.DefaultStackTraceFilterer
+import org.grails.plugins.testing.GrailsMockHttpServletRequest
+import org.grails.plugins.testing.GrailsMockHttpServletResponse
+import org.grails.support.MockApplicationContext
+import org.grails.web.mapping.DefaultUrlMappingEvaluator
+import org.grails.web.mapping.DefaultUrlMappingsHolder
+import org.grails.web.servlet.view.CompositeViewResolver
+
+import static org.junit.jupiter.api.Assertions.assertEquals
+import static org.junit.jupiter.api.Assertions.assertFalse
+import static org.junit.jupiter.api.Assertions.assertNotNull
+import static org.junit.jupiter.api.Assertions.assertThrows
+import static org.junit.jupiter.api.Assertions.assertTrue
+
+/**
+ * Test case for {@link org.grails.web.mapping.mvc.GrailsUrlMappingsExceptionResolver}.
+ */
+class GrailsUrlMappingsExceptionResolverTests {
+
+    private application = new DefaultGrailsApplication()
+    private resolver = new GrailsUrlMappingsExceptionResolver()
+    private mockContext = new MockServletContext()
+    private mockCtx = new MockApplicationContext()
+
+    @AfterEach
+    void tearDown() {
+        RequestContextHolder.resetRequestAttributes()
+    }
+
+    @BeforeEach
+    void setUp() throws Exception {
+        mockCtx.registerMockBean(GrailsApplication.APPLICATION_ID, new DefaultGrailsApplication())
+        def mainContext = new MockApplicationContext();
+        mainContext.registerMockBean(UrlConverter.BEAN_NAME, new CamelCaseUrlConverter());
+        application.mainContext = mainContext
+    }
+
+    @Test
+    void testGetRootCause() {
+        def ex = new Exception()
+        assertEquals ex, GrailsUrlMappingsExceptionResolver.getRootCause(ex)
+
+        def root = new Exception("root")
+        ex = new RuntimeException(root)
+        assertEquals root, GrailsUrlMappingsExceptionResolver.getRootCause(ex)
+
+        ex = new IllegalStateException(ex)
+        assertEquals root, GrailsUrlMappingsExceptionResolver.getRootCause(ex)
+
+        assertThrows(NullPointerException) {
+            GrailsUrlMappingsExceptionResolver.getRootCause(null)
+        }
+    }
+
+    @Test
+    void testResolveExceptionToView() {
+        def mappings = new DefaultUrlMappingEvaluator(mockCtx).evaluateMappings {
+            "500"(view: "myView")
+        }
+
+        def urlMappingsHolder = new DefaultUrlMappingsHolder(mappings)
+        def webRequest = GrailsWebMockUtil.bindMockWebRequest(mockCtx,
+                new GrailsMockHttpServletRequest(), new GrailsMockHttpServletResponse())
+
+        mockCtx.registerMockBean UrlMappingsHolder.BEAN_ID, urlMappingsHolder
+        ViewResolver viewResolver = new DummyViewResolver()
+        mockCtx.registerMockBean "viewResolver", viewResolver
+        mockCtx.registerMockBean 'grailsApplication', application
+        mockCtx.registerMockBean CompositeViewResolver.BEAN_NAME, new CompositeViewResolver(viewResolvers: [viewResolver])
+        mockContext.setAttribute WebApplicationContext.ROOT_WEB_APPLICATION_CONTEXT_ATTRIBUTE, mockCtx
+
+        resolver.servletContext = mockContext
+        resolver.exceptionMappings = ['java.lang.Exception': '/error'] as Properties
+        resolver.grailsApplication = application
+        resolver.stackFilterer = new DefaultStackTraceFilterer()
+
+        def ex = new Exception()
+        def request = webRequest.currentRequest
+        def response = webRequest.currentResponse
+        def handler = new Object()
+        def modelAndView = resolver.resolveException(request, response, handler, ex)
+
+        assertNotNull modelAndView, "should have returned a ModelAndView"
+        assertEquals "/myView", modelAndView.view.url
+    }
+
+    @Test
+    void testResolveExceptionToController() {
+        def mappings = new DefaultUrlMappingEvaluator(mockCtx).evaluateMappings {
+            "500"(controller: "foo", action: "bar")
+        }
+
+        def urlMappingsHolder = new DefaultUrlMappingsHolder(mappings)
+        def webRequest = GrailsWebMockUtil.bindMockWebRequest()
+
+        mockCtx.registerMockBean UrlMappingsHolder.BEAN_ID, urlMappingsHolder
+        mockCtx.registerMockBean "viewResolver", new DummyViewResolver()
+        mockCtx.registerMockBean GrailsApplication.APPLICATION_ID, application
+        mockCtx.registerMockBean "multipartResolver", new StandardServletMultipartResolver()
+        mockContext.setAttribute WebApplicationContext.ROOT_WEB_APPLICATION_CONTEXT_ATTRIBUTE, mockCtx
+
+        resolver.servletContext = mockContext
+        resolver.exceptionMappings = ['java.lang.Exception': '/error'] as Properties
+        resolver.grailsApplication = application
+        resolver.stackFilterer = new DefaultStackTraceFilterer()
+
+        def ex = new Exception()
+        def request = webRequest.currentRequest
+        MockHttpServletResponse response = webRequest.currentResponse
+        def handler = new Object()
+        def modelAndView = resolver.resolveException(request, response, handler, ex)
+
+        assertNotNull modelAndView, "should have returned a ModelAndView"
+        assertTrue modelAndView.empty
+
+        assertEquals "/foo/bar", response.getForwardedUrl()
+    }
+
+    @Test
+    void testResolveExceptionToControllerWhenResponseCommitted() {
+        def mappings = new DefaultUrlMappingEvaluator(mockCtx).evaluateMappings {
+            "500"(controller: "foo", action: "bar")
+        }
+
+        def urlMappingsHolder = new DefaultUrlMappingsHolder(mappings)
+        def webRequest = GrailsWebMockUtil.bindMockWebRequest()
+
+        mockCtx.registerMockBean UrlMappingsHolder.BEAN_ID, urlMappingsHolder
+        mockCtx.registerMockBean "viewResolver", new DummyViewResolver()
+        mockCtx.registerMockBean GrailsApplication.APPLICATION_ID, application
+        mockCtx.registerMockBean "multipartResolver", new StandardServletMultipartResolver()
+        mockContext.setAttribute WebApplicationContext.ROOT_WEB_APPLICATION_CONTEXT_ATTRIBUTE, mockCtx
+
+        resolver.servletContext = mockContext
+        resolver.exceptionMappings = ['java.lang.Exception': '/error'] as Properties
+        resolver.grailsApplication = application
+        resolver.stackFilterer = new DefaultStackTraceFilterer()
+
+        def ex = new Exception()
+        def request = webRequest.currentRequest
+        MockHttpServletResponse response = webRequest.currentResponse
+        def handler = new Object()
+        response.setCommitted(true)
+        def modelAndView = resolver.resolveException(request, response, handler, ex)
+
+        assertNotNull modelAndView, "should have returned a ModelAndView"
+        assertFalse modelAndView.empty
+    }
+
+    @Test
+    void testLogRequestWithException() {
+        def config = new ConfigSlurper().parse('''
+grails.exceptionresolver.params.exclude = ['jennysPhoneNumber']
+''')
+
+        def request = new MockHttpServletRequest()
+        request.setRequestURI("/execute/me")
+        request.setMethod "GET"
+        request.addParameter "foo", "bar"
+        request.addParameter "one", "two"
+        request.addParameter "jennysPhoneNumber", "8675309"
+
+        System.setProperty(Environment.KEY, Environment.DEVELOPMENT.name)
+        def resolver = new GrailsUrlMappingsExceptionResolver(
+                grailsApplication: new DefaultGrailsApplication(config: new PropertySourcesConfig().merge(config)))
+        resolver.stackFilterer = new DefaultStackTraceFilterer()
+        def msg = resolver.getRequestLogMessage(new RuntimeException("bad things happened"), request)
+
+        assertEquals '''RuntimeException occurred when processing request:
+URI: /execute/me
+Method: GET
+Message: bad things happened
+Parameters:
+  - foo: bar
+  - one: two
+  - jennysPhoneNumber: [FILTERED]
+
+Filtered stacktrace:
+'''.replaceAll('[\n\r]', ''), msg.replaceAll('[\n\r]', '')
+    }
+
+    @Test
+    void testLogRequest() {
+        def config = new ConfigSlurper().parse('''
+grails.exceptionresolver.params.exclude = ['jennysPhoneNumber']
+''')
+
+        def request = new MockHttpServletRequest()
+        request.setRequestURI("/execute/me")
+        request.setMethod "GET"
+        request.addParameter "foo", "bar"
+        request.addParameter "one", "two"
+        request.addParameter "jennysPhoneNumber", "8675309"
+
+        System.setProperty(Environment.KEY, Environment.DEVELOPMENT.name)
+        def resolver = new GrailsUrlMappingsExceptionResolver(
+                grailsApplication: new DefaultGrailsApplication(config: new PropertySourcesConfig().merge(config)))
+        resolver.stackFilterer = new DefaultStackTraceFilterer()
+        def msg = resolver.getRequestLogMessage(request)
+
+        assertEquals '''Exception occurred when processing request:
+URI: /execute/me
+Method: GET
+Parameters:
+  - foo: bar
+  - one: two
+  - jennysPhoneNumber: [FILTERED]
+
+Filtered stacktrace:
+'''.replaceAll('[\n\r]', ''), msg.replaceAll('[\n\r]', '')
+    }
+
+    @Test
+    void testDisablingRequestParameterLogging() {
+        def oldEnvName = Environment.current.name
+        try {
+            def request = new MockHttpServletRequest()
+            request.setRequestURI("/execute/me")
+            request.setMethod "GET"
+            request.addParameter "foo", "bar"
+            request.addParameter "one", "two"
+
+            def msgWithParameters = '''Exception occurred when processing request:
+URI: /execute/me
+Method: GET
+Parameters:
+  - foo: bar
+  - one: two
+
+Filtered stacktrace:'''.replaceAll('[\n\r]', '')
+            def msgWithoutParameters = '''Exception occurred when processing request:
+URI: /execute/me
+Method: GET
+
+Filtered stacktrace:'''.replaceAll('[\n\r]', '')
+
+            System.setProperty(Environment.KEY, Environment.DEVELOPMENT.name)
+            def resolver = new GrailsUrlMappingsExceptionResolver(grailsApplication: application)
+            resolver.stackFilterer = new DefaultStackTraceFilterer()
+            def msg = resolver.getRequestLogMessage(request)
+            assertEquals msgWithParameters, msg.replaceAll('[\n\r]', '')
+
+            System.setProperty(Environment.KEY, Environment.PRODUCTION.name)
+            resolver = new GrailsUrlMappingsExceptionResolver(grailsApplication: application)
+            resolver.stackFilterer = new DefaultStackTraceFilterer()
+            msg = resolver.getRequestLogMessage(request)
+            assertEquals msgWithoutParameters, msg.replaceAll('[\n\r]', '')
+
+            System.setProperty(Environment.KEY, Environment.TEST.name)
+            resolver = new GrailsUrlMappingsExceptionResolver(grailsApplication: application)
+            resolver.stackFilterer = new DefaultStackTraceFilterer()
+            msg = resolver.getRequestLogMessage(request)
+            assertEquals msgWithoutParameters, msg.replaceAll('[\n\r]', '')
+
+            def config = new ConfigSlurper().parse('''
+grails.exceptionresolver.logRequestParameters = false
+''')
+
+            System.setProperty(Environment.KEY, Environment.DEVELOPMENT.name)
+            resolver = new GrailsUrlMappingsExceptionResolver(
+                    grailsApplication: new DefaultGrailsApplication(config: new PropertySourcesConfig().merge(config)))
+            resolver.stackFilterer = new DefaultStackTraceFilterer()
+            msg = resolver.getRequestLogMessage(request)
+            assertEquals msgWithoutParameters, msg.replaceAll('[\n\r]', '')
+
+            System.setProperty(Environment.KEY, Environment.PRODUCTION.name)
+            resolver = new GrailsUrlMappingsExceptionResolver(
+                    grailsApplication: new DefaultGrailsApplication(config: new PropertySourcesConfig().merge(config)))
+            resolver.stackFilterer = new DefaultStackTraceFilterer()
+            msg = resolver.getRequestLogMessage(request)
+            assertEquals msgWithoutParameters, msg.replaceAll('[\n\r]', '')
+
+            System.setProperty(Environment.KEY, Environment.TEST.name)
+            resolver = new GrailsUrlMappingsExceptionResolver(
+                    grailsApplication: new DefaultGrailsApplication(config: new PropertySourcesConfig().merge(config)))
+            resolver.stackFilterer = new DefaultStackTraceFilterer()
+            msg = resolver.getRequestLogMessage(request)
+            assertEquals msgWithoutParameters, msg.replaceAll('[\n\r]', '')
+
+            config = new ConfigSlurper().parse('''
+grails.exceptionresolver.logRequestParameters = true
+''')
+
+            System.setProperty(Environment.KEY, Environment.DEVELOPMENT.name)
+            resolver = new GrailsUrlMappingsExceptionResolver(
+                    grailsApplication: new DefaultGrailsApplication(config: new PropertySourcesConfig().merge(config)))
+            resolver.stackFilterer = new DefaultStackTraceFilterer()
+            msg = resolver.getRequestLogMessage(request)
+            assertEquals msgWithParameters, msg.replaceAll('[\n\r]', '')
+
+            System.setProperty(Environment.KEY, Environment.PRODUCTION.name)
+            resolver = new GrailsUrlMappingsExceptionResolver(
+                    grailsApplication: new DefaultGrailsApplication(config: new PropertySourcesConfig().merge(config)))
+            resolver.stackFilterer = new DefaultStackTraceFilterer()
+            msg = resolver.getRequestLogMessage(request)
+            assertEquals msgWithParameters, msg.replaceAll('[\n\r]', '')
+
+            System.setProperty(Environment.KEY, Environment.TEST.name)
+            resolver = new GrailsUrlMappingsExceptionResolver(
+                    grailsApplication: new DefaultGrailsApplication(config: new PropertySourcesConfig().merge(config)))
+            resolver.stackFilterer = new DefaultStackTraceFilterer()
+            msg = resolver.getRequestLogMessage(request)
+            assertEquals msgWithParameters, msg.replaceAll('[\n\r]', '')
+        }
+        finally {
+            System.setProperty(Environment.KEY, oldEnvName)
+        }
+    }
+}
+
+class DummyViewResolver implements ViewResolver {
+
+    @Override
+    View resolveViewName(String viewName, Locale locale) {
+        new InternalResourceView(viewName)
+    }
+
+}


### PR DESCRIPTION
- Introduce `GrailsUrlMappingsExceptionResolver` to make grace-web-mvc decoupled from grace-web-url-mappings
- `GrailsExceptionResolver` should not reuse cached controller attribute to find the given error path
- Cleanup `GrailsWrappedRuntimeException`