### PR TITLE
Refactor Grace Web Rest

### DIFF
--- a/grace-plugin-rest/src/main/groovy/grails/artefact/controller/RestResponder.groovy
+++ b/grace-plugin-rest/src/main/groovy/grails/artefact/controller/RestResponder.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2025 the original author or authors.
+ * Copyright 2014-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -37,7 +37,7 @@ import grails.rest.render.RendererRegistry
 import grails.web.mime.MimeType
 
 import org.grails.datastore.mapping.model.config.GormProperties
-import org.grails.plugins.web.rest.render.ServletRenderContext
+import org.grails.web.rest.render.ServletRenderContext
 import org.grails.web.servlet.mvc.GrailsWebRequest
 import org.grails.web.util.GrailsApplicationAttributes
 

--- a/grace-plugin-rest/src/main/groovy/org/grails/plugins/web/rest/plugin/RestResponderPluginConfiguration.java
+++ b/grace-plugin-rest/src/main/groovy/org/grails/plugins/web/rest/plugin/RestResponderPluginConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2025 the original author or authors.
+ * Copyright 2021-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,9 +31,9 @@ import grails.rest.render.Renderer;
 import grails.rest.render.RendererRegistry;
 import grails.rest.render.RendererRegistryCustomizer;
 
-import org.grails.plugins.web.rest.render.DefaultRendererRegistry;
 import org.grails.plugins.web.rest.render.DefaultRendererRegistryCustomizer;
 import org.grails.web.gsp.io.GrailsConventionGroovyPageLocator;
+import org.grails.web.rest.render.DefaultRendererRegistry;
 
 /**
  * {@link EnableAutoConfiguration Auto-configuration} for Grails RestResponder Plugin.

--- a/grace-plugin-rest/src/main/groovy/org/grails/plugins/web/rest/transform/ResourceTransform.groovy
+++ b/grace-plugin-rest/src/main/groovy/org/grails/plugins/web/rest/transform/ResourceTransform.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2025 the original author or authors.
+ * Copyright 2012-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -75,6 +75,7 @@ import org.grails.compiler.injection.GrailsAwareInjectionOperation
 import org.grails.compiler.injection.TraitInjectionUtils
 import org.grails.compiler.web.ControllerActionTransformer
 import org.grails.datastore.gorm.transactions.transform.TransactionalTransform
+import org.grails.web.rest.transform.LinkableTransform
 
 import static org.grails.compiler.injection.GrailsASTUtils.VOID_CLASS_NODE
 import static org.grails.compiler.injection.GrailsASTUtils.ZERO_PARAMETERS

--- a/grace-plugin-rest/src/test/groovy/org/grails/plugins/web/rest/render/DefaultRendererRegistrySpec.groovy
+++ b/grace-plugin-rest/src/test/groovy/org/grails/plugins/web/rest/render/DefaultRendererRegistrySpec.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2025 the original author or authors.
+ * Copyright 2012-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,6 +19,7 @@ import grails.rest.render.AbstractRenderer
 import grails.rest.render.RenderContext
 import grails.rest.render.hal.HalJsonCollectionRenderer
 import grails.web.mime.MimeType
+import org.grails.web.rest.render.DefaultRendererRegistry;
 import org.springframework.validation.BeanPropertyBindingResult
 import org.springframework.validation.Errors
 import spock.lang.Specification

--- a/grace-plugin-rest/src/test/groovy/org/grails/plugins/web/rest/render/VndErrorRenderingSpec.groovy
+++ b/grace-plugin-rest/src/test/groovy/org/grails/plugins/web/rest/render/VndErrorRenderingSpec.groovy
@@ -16,6 +16,8 @@ import org.grails.support.MockApplicationContext
 import org.grails.web.mapping.DefaultLinkGenerator
 import org.grails.web.mapping.DefaultUrlMappingEvaluator
 import org.grails.web.mapping.DefaultUrlMappingsHolder
+import org.grails.web.rest.render.DefaultRendererRegistry;
+import org.grails.web.rest.render.ServletRenderContext
 import org.springframework.context.support.StaticMessageSource
 import org.springframework.http.HttpStatus
 import org.springframework.mock.web.MockServletContext

--- a/grace-plugin-rest/src/test/groovy/org/grails/plugins/web/rest/render/hal/HalJsonRendererSpec.groovy
+++ b/grace-plugin-rest/src/test/groovy/org/grails/plugins/web/rest/render/hal/HalJsonRendererSpec.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2023 the original author or authors.
+ * Copyright 2012-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -37,12 +37,12 @@ import org.grails.datastore.mapping.model.AbstractPersistentProperty
 import org.grails.datastore.mapping.model.MappingContext
 import org.grails.datastore.mapping.model.PropertyMapping
 import org.grails.plugins.web.mime.MimeTypesFactoryBean
-import org.grails.plugins.web.rest.render.ServletRenderContext
 import org.grails.support.MockApplicationContext
 import org.grails.web.mapping.DefaultLinkGenerator
 import org.grails.web.mapping.DefaultUrlMappingEvaluator
 import org.grails.web.mapping.DefaultUrlMappingsHolder
 import org.grails.web.mime.DefaultMimeUtility
+import org.grails.web.rest.render.ServletRenderContext
 import org.grails.web.servlet.mvc.GrailsWebRequest
 import org.grails.web.servlet.mvc.MockHibernateProxyHandler
 import org.springframework.context.support.StaticMessageSource

--- a/grace-plugin-rest/src/test/groovy/org/grails/plugins/web/rest/render/html/HtmlRendererSpec.groovy
+++ b/grace-plugin-rest/src/test/groovy/org/grails/plugins/web/rest/render/html/HtmlRendererSpec.groovy
@@ -4,8 +4,8 @@ import grails.persistence.Entity
 import grails.validation.ValidationErrors
 import grails.web.mime.MimeType
 import org.grails.web.util.GrailsApplicationAttributes
+import org.grails.web.rest.render.ServletRenderContext
 import org.grails.web.servlet.mvc.GrailsWebRequest
-import org.grails.plugins.web.rest.render.ServletRenderContext
 import org.springframework.mock.web.MockHttpServletRequest
 import org.springframework.mock.web.MockHttpServletResponse
 import org.springframework.mock.web.MockServletContext

--- a/grace-plugin-rest/src/test/groovy/org/grails/plugins/web/rest/render/json/JsonRendererSpec.groovy
+++ b/grace-plugin-rest/src/test/groovy/org/grails/plugins/web/rest/render/json/JsonRendererSpec.groovy
@@ -9,9 +9,9 @@ import org.grails.config.PropertySourcesConfig
 import org.grails.core.lifecycle.ShutdownOperations
 import org.grails.datastore.mapping.keyvalue.mapping.config.KeyValueMappingContext
 import org.grails.datastore.mapping.model.MappingContext
-import org.grails.plugins.web.rest.render.ServletRenderContext
 import org.grails.web.converters.configuration.ConvertersConfigurationHolder
 import org.grails.web.converters.configuration.ConvertersConfigurationInitializer
+import org.grails.web.rest.render.ServletRenderContext
 import org.springframework.context.ApplicationContext
 import spock.lang.Specification
 

--- a/grace-test-suite-uber/src/test/groovy/org/grails/plugins/web/rest/render/atom/AtomDomainClassRendererSpec.groovy
+++ b/grace-test-suite-uber/src/test/groovy/org/grails/plugins/web/rest/render/atom/AtomDomainClassRendererSpec.groovy
@@ -14,7 +14,6 @@ import org.grails.config.PropertySourcesConfig
 import org.grails.datastore.mapping.keyvalue.mapping.config.KeyValueMappingContext
 import org.grails.datastore.mapping.model.MappingContext
 import org.grails.plugins.web.mime.MimeTypesFactoryBean
-import org.grails.plugins.web.rest.render.ServletRenderContext
 import org.grails.plugins.web.rest.render.hal.Author
 import org.grails.plugins.web.rest.render.hal.Book
 import org.grails.support.MockApplicationContext
@@ -22,6 +21,7 @@ import org.grails.web.mapping.DefaultLinkGenerator
 import org.grails.web.mapping.DefaultUrlMappingEvaluator
 import org.grails.web.mapping.DefaultUrlMappingsHolder
 import org.grails.web.mime.DefaultMimeUtility
+import org.grails.web.rest.render.ServletRenderContext
 import org.grails.web.servlet.mvc.GrailsWebRequest
 import org.springframework.context.support.StaticMessageSource
 import org.springframework.core.env.MapPropertySource

--- a/grace-test-suite-uber/src/test/groovy/org/grails/plugins/web/rest/render/hal/HalDomainClassJsonRendererSpec.groovy
+++ b/grace-test-suite-uber/src/test/groovy/org/grails/plugins/web/rest/render/hal/HalDomainClassJsonRendererSpec.groovy
@@ -17,12 +17,12 @@ import org.grails.config.PropertySourcesConfig
 import org.grails.datastore.mapping.keyvalue.mapping.config.KeyValueMappingContext
 import org.grails.datastore.mapping.model.MappingContext
 import org.grails.plugins.web.mime.MimeTypesFactoryBean
-import org.grails.plugins.web.rest.render.ServletRenderContext
 import org.grails.support.MockApplicationContext
 import org.grails.web.mapping.DefaultLinkGenerator
 import org.grails.web.mapping.DefaultUrlMappingEvaluator
 import org.grails.web.mapping.DefaultUrlMappingsHolder
 import org.grails.web.mime.DefaultMimeUtility
+import org.grails.web.rest.render.ServletRenderContext
 import org.grails.web.servlet.mvc.GrailsWebRequest
 import org.springframework.context.support.StaticMessageSource
 import org.springframework.core.env.MapPropertySource

--- a/grace-test-suite-uber/src/test/groovy/org/grails/plugins/web/rest/render/hal/HalDomainClassXmlRendererSpec.groovy
+++ b/grace-test-suite-uber/src/test/groovy/org/grails/plugins/web/rest/render/hal/HalDomainClassXmlRendererSpec.groovy
@@ -14,7 +14,6 @@ import org.grails.config.PropertySourcesConfig
 import org.grails.datastore.mapping.keyvalue.mapping.config.KeyValueMappingContext
 import org.grails.datastore.mapping.model.MappingContext
 import org.grails.plugins.web.mime.MimeTypesFactoryBean
-import org.grails.plugins.web.rest.render.ServletRenderContext
 import org.grails.support.MockApplicationContext
 import org.grails.web.converters.configuration.ConvertersConfigurationHolder
 import org.grails.web.converters.configuration.ConvertersConfigurationInitializer
@@ -22,6 +21,7 @@ import org.grails.web.mapping.DefaultLinkGenerator
 import org.grails.web.mapping.DefaultUrlMappingEvaluator
 import org.grails.web.mapping.DefaultUrlMappingsHolder
 import org.grails.web.mime.DefaultMimeUtility
+import org.grails.web.rest.render.ServletRenderContext
 import org.grails.web.servlet.mvc.GrailsWebRequest
 import org.springframework.context.support.StaticMessageSource
 import org.springframework.core.env.MapPropertySource

--- a/grace-test-suite-web/src/test/groovy/org/grails/plugins/web/rest/render/xml/DefaultXmlRendererSpec.groovy
+++ b/grace-test-suite-web/src/test/groovy/org/grails/plugins/web/rest/render/xml/DefaultXmlRendererSpec.groovy
@@ -10,10 +10,10 @@ import grails.util.GrailsWebUtil
 import grails.validation.ValidationErrors
 import grails.web.mime.MimeType
 
-import org.grails.plugins.web.rest.render.ServletRenderContext
 import org.grails.web.converters.configuration.ConvertersConfigurationHolder
 import org.grails.web.converters.configuration.ConvertersConfigurationInitializer
 import org.grails.web.converters.marshaller.xml.ValidationErrorsMarshaller
+import org.grails.web.rest.render.ServletRenderContext
 import org.grails.web.servlet.mvc.GrailsWebRequest
 import org.springframework.mock.web.MockHttpServletRequest
 import org.springframework.mock.web.MockHttpServletResponse

--- a/grace-test-suite-web/src/test/groovy/org/grails/web/json/DomainClassCollectionRenderingSpec.groovy
+++ b/grace-test-suite-web/src/test/groovy/org/grails/web/json/DomainClassCollectionRenderingSpec.groovy
@@ -4,8 +4,8 @@ import grails.persistence.Entity
 import grails.rest.render.json.JsonRenderer
 import grails.testing.gorm.DataTest
 import grails.testing.web.GrailsWebUnitTest
-import org.grails.plugins.web.rest.render.ServletRenderContext
 import org.grails.web.converters.configuration.ConvertersConfigurationInitializer
+import org.grails.web.rest.render.ServletRenderContext
 import org.grails.web.servlet.mvc.GrailsWebRequest
 import spock.lang.Issue
 import spock.lang.Specification

--- a/grace-test-support/src/main/groovy/org/grails/testing/spock/WebSetupSpecInterceptor.groovy
+++ b/grace-test-support/src/main/groovy/org/grails/testing/spock/WebSetupSpecInterceptor.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2025 the original author or authors.
+ * Copyright 2016-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -41,7 +41,6 @@ import org.grails.gsp.GroovyPagesTemplateEngine
 import org.grails.gsp.jsp.TagLibraryResolverImpl
 import org.grails.plugins.codecs.CodecsGrailsPlugin
 import org.grails.plugins.codecs.DefaultCodecLookup
-import org.grails.plugins.web.rest.render.DefaultRendererRegistry
 import org.grails.plugins.web.rest.render.DefaultRendererRegistryCustomizer
 import org.grails.testing.runtime.support.GroovyPageUnitTestResourceLoader
 import org.grails.testing.runtime.support.LazyTagLibraryLookup
@@ -51,6 +50,7 @@ import org.grails.web.gsp.io.GrailsConventionGroovyPageLocator
 import org.grails.web.mapping.DefaultLinkGenerator
 import org.grails.web.mapping.UrlMappingsHolderFactoryBean
 import org.grails.web.pages.FilteringCodecsByContentTypeSettings
+import org.grails.web.rest.render.DefaultRendererRegistry;
 import org.grails.web.servlet.view.CompositeViewResolver
 import org.grails.web.servlet.view.GroovyPageViewResolver
 import org.grails.web.util.GrailsApplicationAttributes

--- a/grace-views-core/src/main/groovy/grails/views/mvc/renderer/DefaultViewRenderer.groovy
+++ b/grace-views-core/src/main/groovy/grails/views/mvc/renderer/DefaultViewRenderer.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2025 the original author or authors.
+ * Copyright 2015-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,8 +28,8 @@ import grails.views.mvc.SmartViewResolver
 import grails.views.resolve.TemplateResolverUtils
 import grails.web.mime.MimeType
 
-import org.grails.plugins.web.rest.render.ServletRenderContext
 import org.grails.plugins.web.rest.render.html.DefaultHtmlRenderer
+import org.grails.web.rest.render.ServletRenderContext
 import org.grails.web.util.GrailsApplicationAttributes
 
 /**

--- a/grace-views-json/src/main/groovy/org/grails/views/json/renderer/AbstractJsonViewContainerRenderer.groovy
+++ b/grace-views-json/src/main/groovy/org/grails/views/json/renderer/AbstractJsonViewContainerRenderer.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2025 the original author or authors.
+ * Copyright 2015-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,9 +24,9 @@ import grails.rest.render.RenderContext
 import grails.util.GrailsNameUtils
 import grails.views.Views
 
-import org.grails.plugins.web.rest.render.ServletRenderContext
 import org.grails.plugins.web.rest.render.json.DefaultJsonRenderer
 import org.grails.views.json.mvc.JsonViewResolver
+import org.grails.web.rest.render.ServletRenderContext
 
 /**
  * A container renderer that looks up JSON views

--- a/grace-web-rest/src/main/groovy/grails/rest/Link.groovy
+++ b/grace-web-rest/src/main/groovy/grails/rest/Link.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2023 the original author or authors.
+ * Copyright 2013-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/grace-web-rest/src/main/groovy/grails/rest/Linkable.groovy
+++ b/grace-web-rest/src/main/groovy/grails/rest/Linkable.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2022 the original author or authors.
+ * Copyright 2013-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/grace-web-rest/src/main/groovy/grails/rest/Linkable.groovy
+++ b/grace-web-rest/src/main/groovy/grails/rest/Linkable.groovy
@@ -47,7 +47,7 @@ import org.codehaus.groovy.transform.GroovyASTTransformationClass
  */
 @Retention(RetentionPolicy.SOURCE)
 @Target([ElementType.TYPE])
-@GroovyASTTransformationClass('org.grails.plugins.web.rest.transform.LinkableTransform')
+@GroovyASTTransformationClass('org.grails.web.rest.transform.LinkableTransform')
 @interface Linkable {
 
 }

--- a/grace-web-rest/src/main/groovy/org/grails/plugins/web/rest/transform/LinkableTransform.groovy
+++ b/grace-web-rest/src/main/groovy/org/grails/plugins/web/rest/transform/LinkableTransform.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2023 the original author or authors.
+ * Copyright 2013-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/grace-web-rest/src/main/groovy/org/grails/web/rest/render/DefaultRendererRegistry.groovy
+++ b/grace-web-rest/src/main/groovy/org/grails/web/rest/render/DefaultRendererRegistry.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 the original author or authors.
+ * Copyright 2013-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.grails.plugins.web.rest.render
+package org.grails.web.rest.render
 
 import java.util.concurrent.ConcurrentHashMap
 

--- a/grace-web-rest/src/main/groovy/org/grails/web/rest/render/ServletRenderContext.groovy
+++ b/grace-web-rest/src/main/groovy/org/grails/web/rest/render/ServletRenderContext.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2025 the original author or authors.
+ * Copyright 2012-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.grails.plugins.web.rest.render
+package org.grails.web.rest.render
 
 import jakarta.servlet.http.HttpServletRequest
 import jakarta.servlet.http.HttpServletResponse

--- a/grace-web-rest/src/main/groovy/org/grails/web/rest/transform/LinkableTransform.groovy
+++ b/grace-web-rest/src/main/groovy/org/grails/web/rest/transform/LinkableTransform.groovy
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.grails.plugins.web.rest.transform
+package org.grails.web.rest.transform
 
 import java.lang.reflect.Modifier
 


### PR DESCRIPTION
- Relocate `Link` `Linkable` from grace-plugin-rest to grace-web-rest
- Rename package from `org.grails.plugins.web.rest.render` to `org.grails.web.rest.render`