### PR TITLE
Refactor Grace Views

### DIFF
--- a/grace-views-core/build.gradle
+++ b/grace-views-core/build.gradle
@@ -1,12 +1,15 @@
 dependencies {
-    api libs.groovy.core
+    api project(":grace-api")
     api project(":grace-core")
     api project(":grace-encoder")
     compileOnly project(":grace-plugin-api")
-    api project(":grace-plugin-rest")
+    api project(":grace-plugin-mimetypes")
     api project(":grace-web")
+    api project(":grace-web-rest")
     api project(":grace-web-url-mappings")
-    api libs.grace.datastore.gorm.support
+
     api libs.caffeine
+    api libs.grace.datastore.gorm.support
+    api libs.groovy.core
     compileOnly libs.jakarta.servlet
 }

--- a/grace-views-core/build.gradle
+++ b/grace-views-core/build.gradle
@@ -3,7 +3,6 @@ dependencies {
     api project(":grace-core")
     api project(":grace-encoder")
     compileOnly project(":grace-plugin-api")
-    api project(":grace-plugin-mimetypes")
     api project(":grace-web")
     api project(":grace-web-rest")
     api project(":grace-web-url-mappings")

--- a/grace-views-core/build.gradle
+++ b/grace-views-core/build.gradle
@@ -3,7 +3,6 @@ dependencies {
     api project(":grace-core")
     api project(":grace-encoder")
     compileOnly project(":grace-plugin-api")
-    api project(":grace-plugin-domain-class")
     api project(":grace-plugin-rest")
     api project(":grace-web")
     api project(":grace-web-url-mappings")

--- a/grace-views-core/src/main/groovy/grails/views/GenericViewConfiguration.groovy
+++ b/grace-views-core/src/main/groovy/grails/views/GenericViewConfiguration.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2025 the original author or authors.
+ * Copyright 2015-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,6 +21,7 @@ import groovy.text.markup.BaseTemplate
 import groovy.transform.CompileStatic
 import org.springframework.beans.BeanUtils
 
+import grails.artefact.ArtefactTypes
 import grails.config.ConfigMap
 import grails.core.GrailsApplication
 import grails.core.GrailsClass
@@ -29,12 +30,12 @@ import grails.util.Environment
 import grails.util.Metadata
 
 import org.grails.config.CodeGenConfig
-import org.grails.core.artefact.DomainClassArtefactHandler
 
 /**
  * Default configuration
  *
  * @author Graeme Rocher
+ * @author Michael Yan
  * @since 2024.0.0
  */
 @CompileStatic
@@ -110,7 +111,7 @@ trait GenericViewConfiguration implements ViewConfiguration, GrailsApplicationAw
     @Override
     void setGrailsApplication(GrailsApplication grailsApplication) {
         if (grailsApplication != null) {
-            def domainArtefacts = grailsApplication.getArtefacts(DomainClassArtefactHandler.TYPE)
+            def domainArtefacts = grailsApplication.getArtefacts(ArtefactTypes.DOMAIN_CLASS)
             setPackageImports(
                     findUniquePackages(domainArtefacts)
             )

--- a/grace-views-core/src/main/groovy/grails/views/mvc/GenericGroovyTemplateView.groovy
+++ b/grace-views-core/src/main/groovy/grails/views/mvc/GenericGroovyTemplateView.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2025 the original author or authors.
+ * Copyright 2015-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -32,6 +32,7 @@ import grails.views.api.http.Response
 import grails.views.mvc.http.DelegatingParameters
 import grails.web.http.HttpHeaders
 import grails.web.mime.MimeType
+import grails.web.mime.MimeTypeUtils
 
 import org.grails.web.servlet.mvc.GrailsWebRequest
 import org.grails.web.util.GrailsApplicationAttributes
@@ -40,6 +41,7 @@ import org.grails.web.util.GrailsApplicationAttributes
  * An implementation of the Spring AbstractUrlBaseView class for ResolvableGroovyTemplateEngine
  *
  * @author Graeme Rocher
+ * @author Michael Yan
  * @since 2024.0.0
  */
 @CompileStatic
@@ -66,7 +68,8 @@ class GenericGroovyTemplateView extends AbstractUrlBasedView {
         def locale = localeResolver?.resolveLocale(httpServletRequest) ?: Locale.ENGLISH
         def qualifiers = []
         def v = httpServletRequest.getHeader(HttpHeaders.ACCEPT_VERSION)
-        MimeType mimeType = GrailsWebRequest.lookup(httpServletRequest) != null ? httpServletResponse.mimeType : null
+        GrailsWebRequest webRequest = GrailsWebRequest.lookup(httpServletRequest)
+        MimeType mimeType = webRequest != null ? MimeTypeUtils.getMimeTypeForRequest(webRequest) : null
         if (mimeType != null && mimeType != MimeType.ALL) {
             qualifiers.add(mimeType.extension)
         }

--- a/grace-views-core/src/main/groovy/grails/views/mvc/SmartViewResolver.groovy
+++ b/grace-views-core/src/main/groovy/grails/views/mvc/SmartViewResolver.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2025 the original author or authors.
+ * Copyright 2015-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -34,6 +34,9 @@ import grails.views.resolve.TemplateResolverUtils
 import grails.web.http.HttpHeaders
 import grails.web.mapping.LinkGenerator
 import grails.web.mime.MimeType
+import grails.web.mime.MimeTypeUtils
+
+import org.grails.web.servlet.mvc.GrailsWebRequest
 
 /**
  * Spring's default view resolving mechanism only accepts the view name and locale,
@@ -43,6 +46,7 @@ import grails.web.mime.MimeType
  * This aims to fix that whilst reducing complexity
  *
  * @author Graeme Rocher
+ * @author Michael Yan
  * @since 2024.0.0
  */
 @CompileStatic
@@ -148,7 +152,8 @@ class SmartViewResolver implements GrailsConfigurationAware {
     protected List buildQualifiers(HttpServletRequest request, HttpServletResponse response) {
         def qualifiers = []
         def version = request.getHeader(HttpHeaders.ACCEPT_VERSION)
-        MimeType mimeType = response.getMimeType()
+        GrailsWebRequest webRequest = GrailsWebRequest.lookup(request)
+        MimeType mimeType = webRequest != null ? MimeTypeUtils.getMimeTypeForRequest(webRequest) : null
         if (mimeType != null && mimeType != MimeType.ALL) {
             qualifiers.add(mimeType.extension)
         }

--- a/grace-views-core/src/main/groovy/grails/views/mvc/renderer/DefaultViewRenderer.groovy
+++ b/grace-views-core/src/main/groovy/grails/views/mvc/renderer/DefaultViewRenderer.groovy
@@ -21,14 +21,15 @@ import org.springframework.web.servlet.ModelAndView
 import org.springframework.web.servlet.view.AbstractUrlBasedView
 
 import grails.core.support.proxy.ProxyHandler
+import grails.rest.render.AbstractRenderer
 import grails.rest.render.RenderContext
 import grails.rest.render.Renderer
 import grails.rest.render.RendererRegistry
+import grails.util.GrailsNameUtils
 import grails.views.mvc.SmartViewResolver
 import grails.views.resolve.TemplateResolverUtils
 import grails.web.mime.MimeType
 
-import org.grails.plugins.web.rest.render.html.DefaultHtmlRenderer
 import org.grails.web.rest.render.ServletRenderContext
 import org.grails.web.util.GrailsApplicationAttributes
 
@@ -36,11 +37,12 @@ import org.grails.web.util.GrailsApplicationAttributes
  * A renderer implementation that looks up a view from the ViewResolver
  *
  * @author Graeme Rocher
+ * @author Michael Yan
  * @since 2024.0.0
  */
 @InheritConstructors
 @CompileStatic
-abstract class DefaultViewRenderer<T> extends DefaultHtmlRenderer<T> {
+abstract class DefaultViewRenderer<T> extends AbstractRenderer<T> {
 
     public static final String MODEL_OBJECT = 'object'
     final SmartViewResolver viewResolver
@@ -50,6 +52,8 @@ abstract class DefaultViewRenderer<T> extends DefaultHtmlRenderer<T> {
     final RendererRegistry rendererRegistry
 
     final Renderer defaultRenderer
+
+    String suffix = ''
 
     DefaultViewRenderer(Class<T> targetType, MimeType mimeType, SmartViewResolver viewResolver,
                         ProxyHandler proxyHandler, RendererRegistry rendererRegistry, Renderer defaultRenderer) {
@@ -136,6 +140,58 @@ abstract class DefaultViewRenderer<T> extends DefaultHtmlRenderer<T> {
         } else {
             defaultRenderer.render(object, context)
         }
+    }
+
+    protected String resolveModelVariableName(Object object) {
+        if (object != null) {
+            if (proxyHandler != null) {
+                object = proxyHandler.unwrapIfProxy(object)
+            }
+
+            Class<?> type = object.getClass()
+            if (type.isArray()) {
+                return GrailsNameUtils.getPropertyName(type.getComponentType()) + suffix + 'Array'
+            }
+
+            if (object instanceof Collection) {
+                Collection coll = (Collection) object
+                if (coll.isEmpty()) {
+                    return 'emptyCollection'
+                }
+
+                Object first = coll.iterator().next()
+                if (proxyHandler != null) {
+                    first = proxyHandler.unwrapIfProxy(first)
+                }
+                if (coll instanceof List) {
+                    return GrailsNameUtils.getPropertyName(first.getClass()) + suffix + 'List'
+                }
+                if (coll instanceof Set) {
+                    return GrailsNameUtils.getPropertyName(first.getClass()) + suffix + 'Set'
+                }
+                return GrailsNameUtils.getPropertyName(first.getClass()) + suffix + 'Collection'
+            }
+
+            if (object instanceof Map) {
+                Map map = (Map) object
+
+                if (map.isEmpty()) {
+                    return 'emptyMap'
+                }
+
+                Object entry = map.values().iterator().next()
+                if (entry != null) {
+                    if (proxyHandler != null) {
+                        entry = proxyHandler.unwrapIfProxy(entry)
+                    }
+                    return GrailsNameUtils.getPropertyName(entry.getClass()) + suffix + 'Map'
+                }
+            }
+            else {
+                return GrailsNameUtils.getPropertyName(object.getClass()) + suffix
+            }
+        }
+        null
     }
 
     static String templateNameForClass(Class<?> cls) {

--- a/grace-views-json/build.gradle
+++ b/grace-views-json/build.gradle
@@ -1,8 +1,10 @@
 dependencies {
     api project(":grace-core")
+    compileOnly project(":grace-plugin-api")
+    api project(":grace-plugin-validation")
     api project(":grace-views-core")
-    api libs.groovy.json
 
+    api libs.groovy.json
     api libs.spring.boot.autoconfigure
     annotationProcessor libs.spring.boot.autoconfigureProcessor
     annotationProcessor libs.spring.boot.configurationProcessor

--- a/grace-views-json/src/main/groovy/org/grails/views/json/renderer/AbstractJsonViewContainerRenderer.groovy
+++ b/grace-views-json/src/main/groovy/org/grails/views/json/renderer/AbstractJsonViewContainerRenderer.groovy
@@ -17,14 +17,15 @@ package org.grails.views.json.renderer
 
 import groovy.transform.CompileStatic
 import groovy.transform.InheritConstructors
-import org.springframework.beans.factory.annotation.Autowired
 
+import grails.rest.render.AbstractRenderer
 import grails.rest.render.ContainerRenderer
 import grails.rest.render.RenderContext
 import grails.util.GrailsNameUtils
+import grails.util.GrailsWebUtil
 import grails.views.Views
+import grails.web.mime.MimeType
 
-import org.grails.plugins.web.rest.render.json.DefaultJsonRenderer
 import org.grails.views.json.mvc.JsonViewResolver
 import org.grails.web.rest.render.ServletRenderContext
 
@@ -32,44 +33,68 @@ import org.grails.web.rest.render.ServletRenderContext
  * A container renderer that looks up JSON views
  *
  * @author Graeme Rocher
+ * @author Michael Yan
  * @since 2024.0.0
  */
 @CompileStatic
 @InheritConstructors
-abstract class AbstractJsonViewContainerRenderer<T, C> extends DefaultJsonRenderer<T> implements ContainerRenderer<T, C> {
+abstract class AbstractJsonViewContainerRenderer<T, C> extends AbstractRenderer<T> implements ContainerRenderer<T, C> {
 
-    @Autowired
-    JsonViewResolver jsonViewResolver
+    private static final MimeType[] DEFAULT_MIME_TYPES = [MimeType.JSON, MimeType.TEXT_JSON] as MimeType[]
+    String encoding = GrailsWebUtil.DEFAULT_ENCODING
+
+    private JsonViewResolver jsonViewResolver
+
+    AbstractJsonViewContainerRenderer(Class<T> targetType, String encoding) {
+        super(targetType, DEFAULT_MIME_TYPES)
+        this.encoding = encoding
+    }
+
+    AbstractJsonViewContainerRenderer(Class<T> targetType, MimeType[] mimeTypes, String encoding) {
+        super(targetType, mimeTypes)
+        this.encoding = encoding
+    }
+
+    void setJsonViewResolver(JsonViewResolver jsonViewResolver) {
+        this.jsonViewResolver = jsonViewResolver
+    }
 
     @Override
     void render(T object, RenderContext context) {
-        if (jsonViewResolver != null) {
-            String viewUri = "/${context.controllerName}/_${GrailsNameUtils.getPropertyName(targetType)}"
-            def webRequest = ((ServletRenderContext) context).getWebRequest()
-            if (webRequest.controllerNamespace) {
-                viewUri = "/${webRequest.controllerNamespace}" + viewUri
-            }
-            def view = jsonViewResolver.resolveView(viewUri, context.locale)
-            if (view == null) {
-                view = jsonViewResolver.resolveView(targetType, context.locale)
+        String viewUri = "/${context.controllerName}/_${GrailsNameUtils.getPropertyName(targetType)}"
+        def webRequest = ((ServletRenderContext) context).getWebRequest()
+        def request = webRequest.currentRequest
+        def response = webRequest.currentResponse
+
+        if (webRequest.controllerNamespace) {
+            viewUri = "/${webRequest.controllerNamespace}" + viewUri
+        }
+        def view = jsonViewResolver.resolveView(viewUri, context.locale)
+        if (view == null) {
+            view = jsonViewResolver.resolveView(targetType, context.locale)
+        }
+
+        if (view != null) {
+            Map<String, Object> model = (Map<String, Object>) [(resolveModelName()): object]
+            def contextArguments = context.getArguments()
+            def contextModel = contextArguments?.get(Views.MODEL)
+            if (contextModel instanceof Map) {
+                model.putAll((Map) contextModel)
             }
 
-            if (view != null) {
-                Map<String, Object> model = (Map<String, Object>) [(resolveModelName()): object]
-                def contextArguments = context.getArguments()
-                def contextModel = contextArguments?.get(Views.MODEL)
-                if (contextModel instanceof Map) {
-                    model.putAll((Map) contextModel)
-                }
-
-                def request = webRequest.currentRequest
-                def response = webRequest.currentResponse
-                view.render(model, request, response)
-            } else {
-                super.render(object, context)
-            }
+            view.render(model, request, response)
         } else {
-            super.render(object, context)
+            // 404 Not found
+            def notFound = jsonViewResolver.resolveView('/notFound', context.locale)
+            if (notFound != null) {
+                notFound.render([:], request, response)
+            }
+            else {
+                def error = jsonViewResolver.resolveView('/error', context.locale)
+                if (error != null) {
+                    error.render([:], request, response)
+                }
+            }
         }
     }
 

--- a/grace-views-markup/build.gradle
+++ b/grace-views-markup/build.gradle
@@ -1,9 +1,10 @@
 dependencies {
     api project(":grace-core")
+    compileOnly project(":grace-plugin-api")
     api project(":grace-views-core")
+
     api libs.jakarta.annotation.api
     compileOnly libs.jakarta.servlet
-
     api libs.spring.boot.autoconfigure
     annotationProcessor libs.spring.boot.autoconfigureProcessor
     annotationProcessor libs.spring.boot.configurationProcessor


### PR DESCRIPTION
- Decouple grace-views-core from grace--plugin-domain-class
  - Using `ArtefactTypes.DOMAIN_CLASS` instead of `DomainClassArtefactHandler.TYPE`
- Decouple grace-views-core from grace-plugin-rest
  - `DefaultViewRenderer` should extends from `AbstractRenderer` instead of `DefaultHtmlRenderer`
- Decouple grace-views-core from grace-plugin-mimetypes
- Decouple grace-views-json from grace-plugin-rest
- Decouple grace-views-markup from grace-plugin-rest