### PR TITLE
Relocate Controllers API

### DIFF
--- a/grace-plugin-controllers/src/main/groovy/grails/artefact/Controller.groovy
+++ b/grace-plugin-controllers/src/main/groovy/grails/artefact/Controller.groovy
@@ -53,7 +53,7 @@ import org.grails.compiler.injection.GrailsASTUtils
 import org.grails.compiler.web.ControllerActionTransformer
 import org.grails.datastore.mapping.model.config.GormProperties
 import org.grails.plugins.web.api.MimeTypesApiSupport
-import org.grails.plugins.web.controllers.ControllerExceptionHandlerMetaData
+import org.grails.web.controller.ControllerExceptionHandlerMetaData
 import org.grails.web.servlet.mvc.GrailsWebRequest
 import org.grails.web.servlet.mvc.InvalidResponseHandler
 import org.grails.web.servlet.mvc.SynchronizerTokensHolder

--- a/grace-plugin-controllers/src/main/groovy/grails/artefact/Controller.groovy
+++ b/grace-plugin-controllers/src/main/groovy/grails/artefact/Controller.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2025 the original author or authors.
+ * Copyright 2014-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -54,11 +54,11 @@ import org.grails.compiler.web.ControllerActionTransformer
 import org.grails.datastore.mapping.model.config.GormProperties
 import org.grails.plugins.web.api.MimeTypesApiSupport
 import org.grails.plugins.web.controllers.ControllerExceptionHandlerMetaData
-import org.grails.plugins.web.servlet.mvc.InvalidResponseHandler
-import org.grails.plugins.web.servlet.mvc.ValidResponseHandler
 import org.grails.web.servlet.mvc.GrailsWebRequest
+import org.grails.web.servlet.mvc.InvalidResponseHandler
 import org.grails.web.servlet.mvc.SynchronizerTokensHolder
 import org.grails.web.servlet.mvc.TokenResponseHandler
+import org.grails.web.servlet.mvc.ValidResponseHandler
 import org.grails.web.util.GrailsApplicationAttributes
 
 /**

--- a/grace-plugin-controllers/src/main/groovy/grails/artefact/controller/support/ResponseRenderer.groovy
+++ b/grace-plugin-controllers/src/main/groovy/grails/artefact/controller/support/ResponseRenderer.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2025 the original author or authors.
+ * Copyright 2014-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -54,7 +54,7 @@ import org.grails.web.sitemesh.GrailsLayoutView
 import org.grails.web.sitemesh.GroovyPageLayoutFinder
 import org.grails.web.util.GrailsApplicationAttributes
 
-import static org.grails.plugins.web.controllers.metaclass.RenderDynamicMethod.*
+import static org.grails.web.controller.RenderDynamicMethod.*
 
 /**
  *

--- a/grace-plugin-controllers/src/main/groovy/org/grails/compiler/web/ControllerActionTransformer.java
+++ b/grace-plugin-controllers/src/main/groovy/org/grails/compiler/web/ControllerActionTransformer.java
@@ -92,7 +92,7 @@ import org.grails.compiler.injection.GrailsASTUtils;
 import org.grails.compiler.injection.TraitInjectionUtils;
 import org.grails.core.DefaultGrailsControllerClass;
 import org.grails.core.artefact.ControllerArtefactHandler;
-import org.grails.plugins.web.controllers.DefaultControllerExceptionHandlerMetaData;
+import org.grails.web.controller.DefaultControllerExceptionHandlerMetaData;
 import org.grails.web.databinding.DefaultASTDatabindingHelper;
 
 /**

--- a/grace-plugin-controllers/src/main/groovy/org/grails/compiler/web/ControllerDomainTransformer.java
+++ b/grace-plugin-controllers/src/main/groovy/org/grails/compiler/web/ControllerDomainTransformer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the original author or authors.
+ * Copyright 2011-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,7 +24,7 @@ import grails.artefact.ArtefactTypes;
 import grails.compiler.ast.AstTransformer;
 
 import org.grails.compiler.injection.AbstractGrailsArtefactTransformer;
-import org.grails.plugins.web.controllers.api.ControllersDomainBindingApi;
+import org.grails.web.controller.api.ControllersDomainBindingApi;
 import org.grails.web.databinding.DefaultASTDatabindingHelper;
 
 /**

--- a/grace-plugin-interceptors/src/main/groovy/grails/artefact/Interceptor.groovy
+++ b/grace-plugin-interceptors/src/main/groovy/grails/artefact/Interceptor.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2023 the original author or authors.
+ * Copyright 2015-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -37,10 +37,10 @@ import grails.web.api.WebAttributes
 import grails.web.databinding.DataBinder
 import grails.web.mapping.UrlMappingInfo
 
-import org.grails.plugins.web.controllers.metaclass.RenderDynamicMethod
 import org.grails.plugins.web.interceptors.GrailsInterceptorHandlerInterceptorAdapter
 import org.grails.plugins.web.interceptors.InterceptorArtefactHandler
 import org.grails.plugins.web.interceptors.UrlMappingMatcher
+import org.grails.web.controller.RenderDynamicMethod
 import org.grails.web.mapping.mvc.UrlMappingsHandlerMapping
 import org.grails.web.servlet.mvc.GrailsWebRequest
 import org.grails.web.servlet.mvc.exceptions.ControllerExecutionException

--- a/grace-test-suite-persistence/src/test/groovy/org/grails/domain/compiler/DomainPropertiesAccessorSpec.groovy
+++ b/grace-test-suite-persistence/src/test/groovy/org/grails/domain/compiler/DomainPropertiesAccessorSpec.groovy
@@ -1,7 +1,7 @@
 package org.grails.domain.compiler
 
 import grails.persistence.Entity
-import org.grails.plugins.web.controllers.api.ControllersDomainBindingApi
+import org.grails.web.controller.api.ControllersDomainBindingApi
 import spock.lang.Specification
 
 class DomainPropertiesAccessorSpec extends Specification {

--- a/grace-web-mvc/build.gradle
+++ b/grace-web-mvc/build.gradle
@@ -2,6 +2,7 @@ dependencies {
     api project(":grace-gsp")
     compileOnly project(":grace-plugin-api")
     api project(":grace-web")
+    api project(":grace-web-databinding")
 
     compileOnlyApi libs.jakarta.servlet
     compileOnly libs.spring.boot.autoconfigure

--- a/grace-web-mvc/src/main/groovy/org/grails/web/controller/ControllerExceptionHandlerMetaData.java
+++ b/grace-web-mvc/src/main/groovy/org/grails/web/controller/ControllerExceptionHandlerMetaData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 the original author or authors.
+ * Copyright 2013-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.grails.plugins.web.controllers;
+package org.grails.web.controller;
 
 /**
  * Represents meta data which describes an exception handling method

--- a/grace-web-mvc/src/main/groovy/org/grails/web/controller/DefaultControllerExceptionHandlerMetaData.groovy
+++ b/grace-web-mvc/src/main/groovy/org/grails/web/controller/DefaultControllerExceptionHandlerMetaData.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2022 the original author or authors.
+ * Copyright 2013-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.grails.plugins.web.controllers
+package org.grails.web.controller
 
 import groovy.transform.Immutable
 

--- a/grace-web-mvc/src/main/groovy/org/grails/web/controller/RenderDynamicMethod.java
+++ b/grace-web-mvc/src/main/groovy/org/grails/web/controller/RenderDynamicMethod.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.grails.plugins.web.controllers.metaclass;
+package org.grails.web.controller;
 
 /**
  * Allows rendering of text, views, and templates to the response

--- a/grace-web-mvc/src/main/groovy/org/grails/web/controller/api/ControllersDomainBindingApi.java
+++ b/grace-web-mvc/src/main/groovy/org/grails/web/controller/api/ControllersDomainBindingApi.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2023 the original author or authors.
+ * Copyright 2011-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.grails.plugins.web.controllers.api;
+package org.grails.web.controller.api;
 
 import java.util.Map;
 

--- a/grace-web-mvc/src/main/groovy/org/grails/web/servlet/mvc/InvalidResponseHandler.groovy
+++ b/grace-web-mvc/src/main/groovy/org/grails/web/servlet/mvc/InvalidResponseHandler.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2022 the original author or authors.
+ * Copyright 2014-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,30 +13,26 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.grails.plugins.web.servlet.mvc
+package org.grails.web.servlet.mvc
 
 import groovy.transform.CompileStatic
 
-import org.grails.web.servlet.mvc.AbstractTokenResponseHandler
-
 /**
- * Handles a valid token response. See {@link org.grails.web.servlet.mvc.TokenResponseHandler}
+ * Handles an invalid token response. See {@link org.grails.web.servlet.mvc.TokenResponseHandler}
  *
  * @author Graeme Rocher
  * @since 3.0
  */
 @CompileStatic
-class ValidResponseHandler extends AbstractTokenResponseHandler {
+class InvalidResponseHandler extends AbstractTokenResponseHandler {
 
-    def model
-
-    ValidResponseHandler(model) {
-        super(true)
-        this.model = model
+    InvalidResponseHandler() {
+        super(false)
     }
 
+    @Override
     protected Object invalidTokenInternal(Closure callable) {
-        model
+        callable?.call()
     }
 
 }

--- a/grace-web-mvc/src/main/groovy/org/grails/web/servlet/mvc/ValidResponseHandler.groovy
+++ b/grace-web-mvc/src/main/groovy/org/grails/web/servlet/mvc/ValidResponseHandler.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2022 the original author or authors.
+ * Copyright 2014-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,27 +13,29 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.grails.plugins.web.servlet.mvc
+package org.grails.web.servlet.mvc
 
 import groovy.transform.CompileStatic
 
-import org.grails.web.servlet.mvc.AbstractTokenResponseHandler
-
 /**
- * Handles an invalid token response. See {@link org.grails.web.servlet.mvc.TokenResponseHandler}
+ * Handles a valid token response. See {@link org.grails.web.servlet.mvc.TokenResponseHandler}
  *
  * @author Graeme Rocher
  * @since 3.0
  */
 @CompileStatic
-class InvalidResponseHandler extends AbstractTokenResponseHandler {
+class ValidResponseHandler extends AbstractTokenResponseHandler {
 
-    InvalidResponseHandler() {
-        super(false)
+    def model
+
+    ValidResponseHandler(model) {
+        super(true)
+        this.model = model
     }
 
+    @Override
     protected Object invalidTokenInternal(Closure callable) {
-        callable?.call()
+        model
     }
 
 }


### PR DESCRIPTION
Relocate Controller APIs from grace-plugin-controllers to grace-web-mvc

- `InvalidResponseHandler` `ValidResponseHandler`
- `ControllerExceptionHandlerMetaData` `DefaultControllerExceptionHandlerMetaData` `RenderDynamicMethod`
- `ControllersDomainBindingApi`