### PR TITLE
Refactor Grace CLI

### DIFF
--- a/grace-cli/src/main/groovy/grails/cli/command/ApplicationCommand.groovy
+++ b/grace-cli/src/main/groovy/grails/cli/command/ApplicationCommand.groovy
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package grails.cli.commands
+package grails.cli.command
 
 import org.springframework.context.ConfigurableApplicationContext
 

--- a/grace-cli/src/main/groovy/grails/cli/command/ApplicationCommand.groovy
+++ b/grace-cli/src/main/groovy/grails/cli/command/ApplicationCommand.groovy
@@ -17,6 +17,12 @@ package grails.cli.command
 
 import org.springframework.context.ConfigurableApplicationContext
 
+import grails.cli.core.io.FileSystemInteraction
+import grails.cli.core.io.FileSystemInteractionImpl
+import grails.cli.core.template.TemplateRenderer
+import grails.cli.core.template.TemplateRendererImpl
+import grails.codegen.model.ModelBuilder
+
 /**
  * Represents a command that is run against the {@link org.springframework.context.ApplicationContext}
  *
@@ -24,9 +30,16 @@ import org.springframework.context.ConfigurableApplicationContext
  * @author Michael Yan
  * @since 3.0
  */
-trait ApplicationCommand implements Command {
+trait ApplicationCommand implements Command, ModelBuilder {
 
     private ConfigurableApplicationContext applicationContext
+    private ExecutionContext executionContext
+
+    @Delegate
+    TemplateRenderer templateRenderer
+
+    @Delegate
+    FileSystemInteraction fileSystemInteraction
 
     /**
      * Sets the application context of the command
@@ -39,6 +52,25 @@ trait ApplicationCommand implements Command {
 
     ConfigurableApplicationContext getApplicationContext() {
         this.applicationContext
+    }
+
+    /**
+     * Sets the execute context of the command
+     *
+     * @param executionContext The execute context
+     */
+    void setExecutionContext(ExecutionContext executionContext) {
+        this.executionContext = executionContext
+        this.templateRenderer = new TemplateRendererImpl(executionContext.baseDir)
+        this.fileSystemInteraction = new FileSystemInteractionImpl(executionContext.baseDir)
+    }
+
+    ExecutionContext getExecutionContext() {
+        this.executionContext
+    }
+
+    List<String> getArgs() {
+        getExecutionContext().commandLine.remainingArgs
     }
 
     /**

--- a/grace-cli/src/main/groovy/grails/cli/command/ApplicationContextCommandRegistry.java
+++ b/grace-cli/src/main/groovy/grails/cli/command/ApplicationContextCommandRegistry.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package grails.cli.commands;
+package grails.cli.command;
 
 import java.util.Collection;
 import java.util.HashMap;

--- a/grace-cli/src/main/groovy/grails/cli/command/Command.java
+++ b/grace-cli/src/main/groovy/grails/cli/command/Command.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package grails.cli.commands;
+package grails.cli.command;
 
 import grails.util.Described;
 import grails.util.GrailsNameUtils;

--- a/grace-cli/src/main/groovy/grails/cli/command/ExecutionContext.groovy
+++ b/grace-cli/src/main/groovy/grails/cli/command/ExecutionContext.groovy
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package grails.cli.commands
+package grails.cli.command
 
 import groovy.transform.Canonical
 import groovy.transform.CompileStatic

--- a/grace-cli/src/main/groovy/grails/cli/command/GrailsApplicationCommand.groovy
+++ b/grace-cli/src/main/groovy/grails/cli/command/GrailsApplicationCommand.groovy
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package grails.cli.commands
+package grails.cli.command
 
 import grails.cli.core.io.FileSystemInteraction
 import grails.cli.core.io.FileSystemInteractionImpl

--- a/grace-cli/src/main/groovy/grails/cli/command/GrailsApplicationCommand.groovy
+++ b/grace-cli/src/main/groovy/grails/cli/command/GrailsApplicationCommand.groovy
@@ -15,31 +15,11 @@
  */
 package grails.cli.command
 
-import grails.cli.core.io.FileSystemInteraction
-import grails.cli.core.io.FileSystemInteractionImpl
-import grails.cli.core.template.TemplateRenderer
-import grails.cli.core.template.TemplateRendererImpl
-import grails.codegen.model.ModelBuilder
-
-trait GrailsApplicationCommand implements ApplicationCommand, ModelBuilder {
-
-    @Delegate
-    TemplateRenderer templateRenderer
-
-    @Delegate
-    FileSystemInteraction fileSystemInteraction
-
-    ExecutionContext executionContext
+trait GrailsApplicationCommand implements ApplicationCommand {
 
     boolean handle(ExecutionContext executionContext) {
-        this.executionContext = executionContext
-        this.templateRenderer = new TemplateRendererImpl(executionContext.baseDir)
-        this.fileSystemInteraction = new FileSystemInteractionImpl(executionContext.baseDir)
+        setExecutionContext(executionContext)
         handle()
-    }
-
-    List<String> getArgs() {
-        executionContext.commandLine.remainingArgs
     }
 
     abstract boolean handle()

--- a/grace-console/src/main/groovy/grails/ui/command/GrailsApplicationCommandRunner.groovy
+++ b/grace-console/src/main/groovy/grails/ui/command/GrailsApplicationCommandRunner.groovy
@@ -20,9 +20,9 @@ import groovy.transform.CompileStatic
 import org.springframework.beans.factory.config.AutowireCapableBeanFactory
 import org.springframework.context.ConfigurableApplicationContext
 
-import grails.cli.commands.ApplicationCommand
-import grails.cli.commands.ApplicationContextCommandRegistry
-import grails.cli.commands.ExecutionContext
+import grails.cli.command.ApplicationCommand
+import grails.cli.command.ApplicationContextCommandRegistry
+import grails.cli.command.ExecutionContext
 import grails.config.Settings
 import grails.ui.support.DevelopmentGrails
 

--- a/grace-console/src/main/groovy/grails/ui/command/GrailsApplicationCommandRunner.groovy
+++ b/grace-console/src/main/groovy/grails/ui/command/GrailsApplicationCommandRunner.groovy
@@ -65,9 +65,11 @@ class GrailsApplicationCommandRunner extends DevelopmentGrails {
             try {
                 console.addStatus("Command :$command.name")
                 CommandLine commandLine = new CommandLineParser().parse(args)
+                ExecutionContext executionContext = new ExecutionContext(commandLine)
                 ctx.autowireCapableBeanFactory.autowireBeanProperties(command, AutowireCapableBeanFactory.AUTOWIRE_BY_TYPE, false)
                 command.applicationContext = ctx
-                boolean result = command.handle(new ExecutionContext(commandLine))
+                command.executionContext = executionContext
+                boolean result = command.handle(executionContext)
                 result ? console.addStatus('EXECUTE SUCCESSFUL') : console.error('EXECUTE FAILED', '')
             }
             catch (Throwable e) {

--- a/grace-core/src/main/groovy/org/grails/compiler/injection/GlobalGrailsClassInjectorTransformation.groovy
+++ b/grace-core/src/main/groovy/org/grails/compiler/injection/GlobalGrailsClassInjectorTransformation.groovy
@@ -53,7 +53,7 @@ class GlobalGrailsClassInjectorTransformation implements ASTTransformation, Comp
     static final ClassNode ARTEFACT_CLASS_NODE = ClassHelper.make(Artefact)
     static final ClassNode CLASS_INJECTOR_CLASS = ClassHelper.make(ClassInjector)
     static final ClassNode TRAIT_INJECTOR_CLASS = ClassHelper.make(TraitInjector)
-    static final ClassNode APPLICATION_CONTEXT_COMMAND_CLASS = ClassHelper.make('grails.cli.commands.ApplicationCommand')
+    static final ClassNode APPLICATION_CONTEXT_COMMAND_CLASS = ClassHelper.make('grails.cli.command.ApplicationCommand')
 
     CompilationUnit compilationUnit
 

--- a/grace-gradle-plugin/src/main/groovy/org/grails/gradle/plugin/commands/ApplicationContextCommandTask.groovy
+++ b/grace-gradle-plugin/src/main/groovy/org/grails/gradle/plugin/commands/ApplicationContextCommandTask.groovy
@@ -19,7 +19,7 @@ import groovy.transform.CompileStatic
 import org.gradle.api.tasks.JavaExec
 
 /**
- * The task to run {@link grails.cli.commands.ApplicationCommand}
+ * The task to run {@link grails.cli.command.ApplicationCommand}
  *
  * @author Graeme Rocher
  * @author Michael Yan

--- a/grace-gradle-plugin/src/main/groovy/org/grails/gradle/plugin/core/GrailsGradlePlugin.groovy
+++ b/grace-gradle-plugin/src/main/groovy/org/grails/gradle/plugin/core/GrailsGradlePlugin.groovy
@@ -50,7 +50,7 @@ import org.springframework.boot.gradle.dsl.SpringBootExtension
 import org.springframework.boot.gradle.plugin.SpringBootPlugin
 import org.springframework.boot.gradle.tasks.run.BootRun
 
-import grails.cli.commands.ApplicationCommand
+import grails.cli.command.ApplicationCommand
 import grails.util.Environment
 import grails.util.GrailsNameUtils
 import grails.util.Metadata

--- a/grace-plugin-database-migration/src/main/groovy/org/grails/plugins/databasemigration/command/ApplicationContextDatabaseMigrationCommand.groovy
+++ b/grace-plugin-database-migration/src/main/groovy/org/grails/plugins/databasemigration/command/ApplicationContextDatabaseMigrationCommand.groovy
@@ -26,7 +26,7 @@ import org.hibernate.engine.jdbc.spi.JdbcServices
 import org.hibernate.engine.spi.SessionFactoryImplementor
 import org.springframework.context.ConfigurableApplicationContext
 
-import grails.cli.commands.ExecutionContext
+import grails.cli.command.ExecutionContext
 import grails.config.ConfigMap
 import grails.core.GrailsApplication
 import grails.util.Environment

--- a/grace-plugin-database-migration/src/main/groovy/org/grails/plugins/databasemigration/command/DbmChangelogSyncCommand.groovy
+++ b/grace-plugin-database-migration/src/main/groovy/org/grails/plugins/databasemigration/command/DbmChangelogSyncCommand.groovy
@@ -18,7 +18,7 @@ package org.grails.plugins.databasemigration.command
 import groovy.transform.CompileStatic
 import liquibase.Liquibase
 
-import grails.cli.commands.ApplicationCommand
+import grails.cli.command.ApplicationCommand
 
 @CompileStatic
 class DbmChangelogSyncCommand implements ApplicationCommand, ApplicationContextDatabaseMigrationCommand {

--- a/grace-plugin-database-migration/src/main/groovy/org/grails/plugins/databasemigration/command/DbmChangelogSyncSqlCommand.groovy
+++ b/grace-plugin-database-migration/src/main/groovy/org/grails/plugins/databasemigration/command/DbmChangelogSyncSqlCommand.groovy
@@ -18,7 +18,7 @@ package org.grails.plugins.databasemigration.command
 import groovy.transform.CompileStatic
 import liquibase.Liquibase
 
-import grails.cli.commands.ApplicationCommand
+import grails.cli.command.ApplicationCommand
 
 @CompileStatic
 class DbmChangelogSyncSqlCommand implements ApplicationCommand, ApplicationContextDatabaseMigrationCommand {

--- a/grace-plugin-database-migration/src/main/groovy/org/grails/plugins/databasemigration/command/DbmClearChecksumsCommand.groovy
+++ b/grace-plugin-database-migration/src/main/groovy/org/grails/plugins/databasemigration/command/DbmClearChecksumsCommand.groovy
@@ -18,7 +18,7 @@ package org.grails.plugins.databasemigration.command
 import groovy.transform.CompileStatic
 import liquibase.Liquibase
 
-import grails.cli.commands.ApplicationCommand
+import grails.cli.command.ApplicationCommand
 
 @CompileStatic
 class DbmClearChecksumsCommand implements ApplicationCommand, ApplicationContextDatabaseMigrationCommand {

--- a/grace-plugin-database-migration/src/main/groovy/org/grails/plugins/databasemigration/command/DbmDbDocCommand.groovy
+++ b/grace-plugin-database-migration/src/main/groovy/org/grails/plugins/databasemigration/command/DbmDbDocCommand.groovy
@@ -18,7 +18,7 @@ package org.grails.plugins.databasemigration.command
 import groovy.transform.CompileStatic
 import liquibase.Liquibase
 
-import grails.cli.commands.ApplicationCommand
+import grails.cli.command.ApplicationCommand
 
 @CompileStatic
 class DbmDbDocCommand implements ApplicationCommand, ApplicationContextDatabaseMigrationCommand {

--- a/grace-plugin-database-migration/src/main/groovy/org/grails/plugins/databasemigration/command/DbmDiffCommand.groovy
+++ b/grace-plugin-database-migration/src/main/groovy/org/grails/plugins/databasemigration/command/DbmDiffCommand.groovy
@@ -18,7 +18,7 @@ package org.grails.plugins.databasemigration.command
 import groovy.transform.CompileStatic
 import liquibase.database.Database
 
-import grails.cli.commands.ApplicationCommand
+import grails.cli.command.ApplicationCommand
 import grails.util.Environment
 
 import org.grails.plugins.databasemigration.DatabaseMigrationException

--- a/grace-plugin-database-migration/src/main/groovy/org/grails/plugins/databasemigration/command/DbmDropAllCommand.groovy
+++ b/grace-plugin-database-migration/src/main/groovy/org/grails/plugins/databasemigration/command/DbmDropAllCommand.groovy
@@ -19,7 +19,7 @@ import groovy.transform.CompileStatic
 import liquibase.CatalogAndSchema
 import liquibase.Liquibase
 
-import grails.cli.commands.ApplicationCommand
+import grails.cli.command.ApplicationCommand
 
 @CompileStatic
 class DbmDropAllCommand implements ApplicationCommand, ApplicationContextDatabaseMigrationCommand {

--- a/grace-plugin-database-migration/src/main/groovy/org/grails/plugins/databasemigration/command/DbmFutureRollbackCountSqlCommand.groovy
+++ b/grace-plugin-database-migration/src/main/groovy/org/grails/plugins/databasemigration/command/DbmFutureRollbackCountSqlCommand.groovy
@@ -18,7 +18,7 @@ package org.grails.plugins.databasemigration.command
 import groovy.transform.CompileStatic
 import liquibase.Liquibase
 
-import grails.cli.commands.ApplicationCommand
+import grails.cli.command.ApplicationCommand
 
 import org.grails.plugins.databasemigration.DatabaseMigrationException
 

--- a/grace-plugin-database-migration/src/main/groovy/org/grails/plugins/databasemigration/command/DbmFutureRollbackSqlCommand.groovy
+++ b/grace-plugin-database-migration/src/main/groovy/org/grails/plugins/databasemigration/command/DbmFutureRollbackSqlCommand.groovy
@@ -18,7 +18,7 @@ package org.grails.plugins.databasemigration.command
 import groovy.transform.CompileStatic
 import liquibase.Liquibase
 
-import grails.cli.commands.ApplicationCommand
+import grails.cli.command.ApplicationCommand
 
 @CompileStatic
 class DbmFutureRollbackSqlCommand implements ApplicationCommand, ApplicationContextDatabaseMigrationCommand {

--- a/grace-plugin-database-migration/src/main/groovy/org/grails/plugins/databasemigration/command/DbmGenerateChangelogCommand.groovy
+++ b/grace-plugin-database-migration/src/main/groovy/org/grails/plugins/databasemigration/command/DbmGenerateChangelogCommand.groovy
@@ -18,7 +18,7 @@ package org.grails.plugins.databasemigration.command
 import groovy.transform.CompileStatic
 import liquibase.database.Database
 
-import grails.cli.commands.ApplicationCommand
+import grails.cli.command.ApplicationCommand
 
 import org.grails.plugins.databasemigration.DatabaseMigrationException
 

--- a/grace-plugin-database-migration/src/main/groovy/org/grails/plugins/databasemigration/command/DbmGenerateGormChangelogCommand.groovy
+++ b/grace-plugin-database-migration/src/main/groovy/org/grails/plugins/databasemigration/command/DbmGenerateGormChangelogCommand.groovy
@@ -18,7 +18,7 @@ package org.grails.plugins.databasemigration.command
 import groovy.transform.CompileStatic
 import liquibase.database.Database
 
-import grails.cli.commands.ApplicationCommand
+import grails.cli.command.ApplicationCommand
 
 import org.grails.plugins.databasemigration.DatabaseMigrationException
 

--- a/grace-plugin-database-migration/src/main/groovy/org/grails/plugins/databasemigration/command/DbmGormDiffCommand.groovy
+++ b/grace-plugin-database-migration/src/main/groovy/org/grails/plugins/databasemigration/command/DbmGormDiffCommand.groovy
@@ -18,7 +18,7 @@ package org.grails.plugins.databasemigration.command
 import groovy.transform.CompileStatic
 import liquibase.database.Database
 
-import grails.cli.commands.ApplicationCommand
+import grails.cli.command.ApplicationCommand
 
 import org.grails.plugins.databasemigration.DatabaseMigrationException
 

--- a/grace-plugin-database-migration/src/main/groovy/org/grails/plugins/databasemigration/command/DbmListLocksCommand.groovy
+++ b/grace-plugin-database-migration/src/main/groovy/org/grails/plugins/databasemigration/command/DbmListLocksCommand.groovy
@@ -20,7 +20,7 @@ import groovy.transform.stc.ClosureParams
 import groovy.transform.stc.SimpleType
 import liquibase.Liquibase
 
-import grails.cli.commands.ApplicationCommand
+import grails.cli.command.ApplicationCommand
 
 @CompileStatic
 class DbmListLocksCommand implements ApplicationCommand, ApplicationContextDatabaseMigrationCommand {

--- a/grace-plugin-database-migration/src/main/groovy/org/grails/plugins/databasemigration/command/DbmMarkNextChangesetRanCommand.groovy
+++ b/grace-plugin-database-migration/src/main/groovy/org/grails/plugins/databasemigration/command/DbmMarkNextChangesetRanCommand.groovy
@@ -18,7 +18,7 @@ package org.grails.plugins.databasemigration.command
 import groovy.transform.CompileStatic
 import liquibase.Liquibase
 
-import grails.cli.commands.ApplicationCommand
+import grails.cli.command.ApplicationCommand
 
 @CompileStatic
 class DbmMarkNextChangesetRanCommand implements ApplicationCommand, ApplicationContextDatabaseMigrationCommand {

--- a/grace-plugin-database-migration/src/main/groovy/org/grails/plugins/databasemigration/command/DbmMarkNextChangesetRanSqlCommand.groovy
+++ b/grace-plugin-database-migration/src/main/groovy/org/grails/plugins/databasemigration/command/DbmMarkNextChangesetRanSqlCommand.groovy
@@ -18,7 +18,7 @@ package org.grails.plugins.databasemigration.command
 import groovy.transform.CompileStatic
 import liquibase.Liquibase
 
-import grails.cli.commands.ApplicationCommand
+import grails.cli.command.ApplicationCommand
 
 @CompileStatic
 class DbmMarkNextChangesetRanSqlCommand implements ApplicationCommand, ApplicationContextDatabaseMigrationCommand {

--- a/grace-plugin-database-migration/src/main/groovy/org/grails/plugins/databasemigration/command/DbmPreviousChangesetSqlCommand.groovy
+++ b/grace-plugin-database-migration/src/main/groovy/org/grails/plugins/databasemigration/command/DbmPreviousChangesetSqlCommand.groovy
@@ -19,7 +19,7 @@ import groovy.transform.CompileStatic
 import liquibase.Liquibase
 import liquibase.database.Database
 
-import grails.cli.commands.ApplicationCommand
+import grails.cli.command.ApplicationCommand
 
 import org.grails.plugins.databasemigration.DatabaseMigrationException
 

--- a/grace-plugin-database-migration/src/main/groovy/org/grails/plugins/databasemigration/command/DbmReleaseLocksCommand.groovy
+++ b/grace-plugin-database-migration/src/main/groovy/org/grails/plugins/databasemigration/command/DbmReleaseLocksCommand.groovy
@@ -18,7 +18,7 @@ package org.grails.plugins.databasemigration.command
 import groovy.transform.CompileStatic
 import liquibase.Liquibase
 
-import grails.cli.commands.ApplicationCommand
+import grails.cli.command.ApplicationCommand
 
 @CompileStatic
 class DbmReleaseLocksCommand implements ApplicationCommand, ApplicationContextDatabaseMigrationCommand {

--- a/grace-plugin-database-migration/src/main/groovy/org/grails/plugins/databasemigration/command/DbmRollbackCommand.groovy
+++ b/grace-plugin-database-migration/src/main/groovy/org/grails/plugins/databasemigration/command/DbmRollbackCommand.groovy
@@ -18,7 +18,7 @@ package org.grails.plugins.databasemigration.command
 import groovy.transform.CompileStatic
 import liquibase.Liquibase
 
-import grails.cli.commands.ApplicationCommand
+import grails.cli.command.ApplicationCommand
 
 import org.grails.plugins.databasemigration.DatabaseMigrationException
 

--- a/grace-plugin-database-migration/src/main/groovy/org/grails/plugins/databasemigration/command/DbmRollbackCountCommand.groovy
+++ b/grace-plugin-database-migration/src/main/groovy/org/grails/plugins/databasemigration/command/DbmRollbackCountCommand.groovy
@@ -18,7 +18,7 @@ package org.grails.plugins.databasemigration.command
 import groovy.transform.CompileStatic
 import liquibase.Liquibase
 
-import grails.cli.commands.ApplicationCommand
+import grails.cli.command.ApplicationCommand
 
 import org.grails.plugins.databasemigration.DatabaseMigrationException
 

--- a/grace-plugin-database-migration/src/main/groovy/org/grails/plugins/databasemigration/command/DbmRollbackCountSqlCommand.groovy
+++ b/grace-plugin-database-migration/src/main/groovy/org/grails/plugins/databasemigration/command/DbmRollbackCountSqlCommand.groovy
@@ -18,7 +18,7 @@ package org.grails.plugins.databasemigration.command
 import groovy.transform.CompileStatic
 import liquibase.Liquibase
 
-import grails.cli.commands.ApplicationCommand
+import grails.cli.command.ApplicationCommand
 
 import org.grails.plugins.databasemigration.DatabaseMigrationException
 

--- a/grace-plugin-database-migration/src/main/groovy/org/grails/plugins/databasemigration/command/DbmRollbackSqlCommand.groovy
+++ b/grace-plugin-database-migration/src/main/groovy/org/grails/plugins/databasemigration/command/DbmRollbackSqlCommand.groovy
@@ -18,7 +18,7 @@ package org.grails.plugins.databasemigration.command
 import groovy.transform.CompileStatic
 import liquibase.Liquibase
 
-import grails.cli.commands.ApplicationCommand
+import grails.cli.command.ApplicationCommand
 
 import org.grails.plugins.databasemigration.DatabaseMigrationException
 

--- a/grace-plugin-database-migration/src/main/groovy/org/grails/plugins/databasemigration/command/DbmRollbackToDateCommand.groovy
+++ b/grace-plugin-database-migration/src/main/groovy/org/grails/plugins/databasemigration/command/DbmRollbackToDateCommand.groovy
@@ -20,7 +20,7 @@ import java.text.ParseException
 import groovy.transform.CompileStatic
 import liquibase.Liquibase
 
-import grails.cli.commands.ApplicationCommand
+import grails.cli.command.ApplicationCommand
 
 import org.grails.plugins.databasemigration.DatabaseMigrationException
 

--- a/grace-plugin-database-migration/src/main/groovy/org/grails/plugins/databasemigration/command/DbmRollbackToDateSqlCommand.groovy
+++ b/grace-plugin-database-migration/src/main/groovy/org/grails/plugins/databasemigration/command/DbmRollbackToDateSqlCommand.groovy
@@ -20,7 +20,7 @@ import java.text.ParseException
 import groovy.transform.CompileStatic
 import liquibase.Liquibase
 
-import grails.cli.commands.ApplicationCommand
+import grails.cli.command.ApplicationCommand
 
 import org.grails.plugins.databasemigration.DatabaseMigrationException
 

--- a/grace-plugin-database-migration/src/main/groovy/org/grails/plugins/databasemigration/command/DbmStatusCommand.groovy
+++ b/grace-plugin-database-migration/src/main/groovy/org/grails/plugins/databasemigration/command/DbmStatusCommand.groovy
@@ -18,7 +18,7 @@ package org.grails.plugins.databasemigration.command
 import groovy.transform.CompileStatic
 import liquibase.Liquibase
 
-import grails.cli.commands.ApplicationCommand
+import grails.cli.command.ApplicationCommand
 
 @CompileStatic
 class DbmStatusCommand implements ApplicationCommand, ApplicationContextDatabaseMigrationCommand {

--- a/grace-plugin-database-migration/src/main/groovy/org/grails/plugins/databasemigration/command/DbmTagCommand.groovy
+++ b/grace-plugin-database-migration/src/main/groovy/org/grails/plugins/databasemigration/command/DbmTagCommand.groovy
@@ -18,7 +18,7 @@ package org.grails.plugins.databasemigration.command
 import groovy.transform.CompileStatic
 import liquibase.Liquibase
 
-import grails.cli.commands.ApplicationCommand
+import grails.cli.command.ApplicationCommand
 
 import org.grails.plugins.databasemigration.DatabaseMigrationException
 

--- a/grace-plugin-database-migration/src/main/groovy/org/grails/plugins/databasemigration/command/DbmUpdateCommand.groovy
+++ b/grace-plugin-database-migration/src/main/groovy/org/grails/plugins/databasemigration/command/DbmUpdateCommand.groovy
@@ -18,7 +18,7 @@ package org.grails.plugins.databasemigration.command
 import groovy.transform.CompileStatic
 import liquibase.Liquibase
 
-import grails.cli.commands.ApplicationCommand
+import grails.cli.command.ApplicationCommand
 
 @CompileStatic
 class DbmUpdateCommand implements ApplicationCommand, ApplicationContextDatabaseMigrationCommand {

--- a/grace-plugin-database-migration/src/main/groovy/org/grails/plugins/databasemigration/command/DbmUpdateCountCommand.groovy
+++ b/grace-plugin-database-migration/src/main/groovy/org/grails/plugins/databasemigration/command/DbmUpdateCountCommand.groovy
@@ -18,7 +18,7 @@ package org.grails.plugins.databasemigration.command
 import groovy.transform.CompileStatic
 import liquibase.Liquibase
 
-import grails.cli.commands.ApplicationCommand
+import grails.cli.command.ApplicationCommand
 
 import org.grails.plugins.databasemigration.DatabaseMigrationException
 

--- a/grace-plugin-database-migration/src/main/groovy/org/grails/plugins/databasemigration/command/DbmUpdateCountSqlCommand.groovy
+++ b/grace-plugin-database-migration/src/main/groovy/org/grails/plugins/databasemigration/command/DbmUpdateCountSqlCommand.groovy
@@ -18,7 +18,7 @@ package org.grails.plugins.databasemigration.command
 import groovy.transform.CompileStatic
 import liquibase.Liquibase
 
-import grails.cli.commands.ApplicationCommand
+import grails.cli.command.ApplicationCommand
 
 import org.grails.plugins.databasemigration.DatabaseMigrationException
 

--- a/grace-plugin-database-migration/src/main/groovy/org/grails/plugins/databasemigration/command/DbmUpdateSqlCommand.groovy
+++ b/grace-plugin-database-migration/src/main/groovy/org/grails/plugins/databasemigration/command/DbmUpdateSqlCommand.groovy
@@ -18,7 +18,7 @@ package org.grails.plugins.databasemigration.command
 import groovy.transform.CompileStatic
 import liquibase.Liquibase
 
-import grails.cli.commands.ApplicationCommand
+import grails.cli.command.ApplicationCommand
 
 @CompileStatic
 class DbmUpdateSqlCommand implements ApplicationCommand, ApplicationContextDatabaseMigrationCommand {

--- a/grace-plugin-database-migration/src/main/groovy/org/grails/plugins/databasemigration/command/DbmValidateCommand.groovy
+++ b/grace-plugin-database-migration/src/main/groovy/org/grails/plugins/databasemigration/command/DbmValidateCommand.groovy
@@ -18,7 +18,7 @@ package org.grails.plugins.databasemigration.command
 import groovy.transform.CompileStatic
 import liquibase.Liquibase
 
-import grails.cli.commands.ApplicationCommand
+import grails.cli.command.ApplicationCommand
 
 @CompileStatic
 class DbmValidateCommand implements ApplicationCommand, ApplicationContextDatabaseMigrationCommand {

--- a/grace-plugin-database-migration/src/main/groovy/org/grails/plugins/databasemigration/command/SchemaExportCommand.groovy
+++ b/grace-plugin-database-migration/src/main/groovy/org/grails/plugins/databasemigration/command/SchemaExportCommand.groovy
@@ -20,8 +20,8 @@ import org.hibernate.engine.spi.SessionFactoryImplementor
 import org.hibernate.tool.hbm2ddl.SchemaExport as HibernateSchemaExport
 import org.hibernate.tool.schema.TargetType
 
-import grails.cli.commands.ApplicationCommand
-import grails.cli.commands.ExecutionContext
+import grails.cli.command.ApplicationCommand
+import grails.cli.command.ExecutionContext
 import grails.util.Environment
 
 import org.grails.build.parsing.CommandLine

--- a/grace-plugin-database-migration/src/main/resources/META-INF/grails.factories
+++ b/grace-plugin-database-migration/src/main/resources/META-INF/grails.factories
@@ -1,4 +1,4 @@
-grails.cli.commands.ApplicationCommand=\
+grails.cli.command.ApplicationCommand=\
 org.grails.plugins.databasemigration.command.DbmChangelogSyncCommand,\
 org.grails.plugins.databasemigration.command.DbmChangelogSyncSqlCommand,\
 org.grails.plugins.databasemigration.command.DbmClearChecksumsCommand,\

--- a/grace-plugin-database-migration/src/test/groovy/org/grails/plugins/databasemigration/command/ApplicationContextDatabaseMigrationCommandSpec.groovy
+++ b/grace-plugin-database-migration/src/test/groovy/org/grails/plugins/databasemigration/command/ApplicationContextDatabaseMigrationCommandSpec.groovy
@@ -1,7 +1,22 @@
+/*
+ * Copyright 2015-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.grails.plugins.databasemigration.command
 
-import grails.cli.commands.ApplicationCommand
-import grails.cli.commands.ExecutionContext
+import grails.cli.command.ApplicationCommand
+import grails.cli.command.ExecutionContext
 import grails.config.Config
 import grails.core.DefaultGrailsApplication
 import grails.core.GrailsApplication

--- a/grace-plugin-database-migration/src/test/groovy/org/grails/plugins/databasemigration/command/DbmChangelogSyncCommandSpec.groovy
+++ b/grace-plugin-database-migration/src/test/groovy/org/grails/plugins/databasemigration/command/DbmChangelogSyncCommandSpec.groovy
@@ -1,11 +1,11 @@
 /*
- * Copyright 2015 original authors
+ * Copyright 2015-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -15,7 +15,7 @@
  */
 package org.grails.plugins.databasemigration.command
 
-import grails.cli.commands.ApplicationCommand
+import grails.cli.command.ApplicationCommand
 
 class DbmChangelogSyncCommandSpec extends ApplicationContextDatabaseMigrationCommandSpec {
 

--- a/grace-plugin-database-migration/src/test/groovy/org/grails/plugins/databasemigration/command/DbmChangelogSyncCommandSqlSpec.groovy
+++ b/grace-plugin-database-migration/src/test/groovy/org/grails/plugins/databasemigration/command/DbmChangelogSyncCommandSqlSpec.groovy
@@ -1,11 +1,11 @@
 /*
- * Copyright 2015 original authors
+ * Copyright 2015-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -15,7 +15,7 @@
  */
 package org.grails.plugins.databasemigration.command
 
-import grails.cli.commands.ApplicationCommand
+import grails.cli.command.ApplicationCommand
 import spock.lang.AutoCleanup
 
 class DbmChangelogSyncCommandSqlSpec extends ApplicationContextDatabaseMigrationCommandSpec {

--- a/grace-plugin-database-migration/src/test/groovy/org/grails/plugins/databasemigration/command/DbmClearChecksumsCommandSpec.groovy
+++ b/grace-plugin-database-migration/src/test/groovy/org/grails/plugins/databasemigration/command/DbmClearChecksumsCommandSpec.groovy
@@ -1,11 +1,11 @@
 /*
- * Copyright 2015 original authors
+ * Copyright 2015-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -15,7 +15,7 @@
  */
 package org.grails.plugins.databasemigration.command
 
-import grails.cli.commands.ApplicationCommand
+import grails.cli.command.ApplicationCommand
 
 class DbmClearChecksumsCommandSpec extends ApplicationContextDatabaseMigrationCommandSpec {
 

--- a/grace-plugin-database-migration/src/test/groovy/org/grails/plugins/databasemigration/command/DbmDiffCommandSpec.groovy
+++ b/grace-plugin-database-migration/src/test/groovy/org/grails/plugins/databasemigration/command/DbmDiffCommandSpec.groovy
@@ -1,11 +1,11 @@
 /*
- * Copyright 2015 original authors
+ * Copyright 2015-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -15,7 +15,7 @@
  */
 package org.grails.plugins.databasemigration.command
 
-import grails.cli.commands.ApplicationCommand
+import grails.cli.command.ApplicationCommand
 import groovy.sql.Sql
 import org.grails.plugins.databasemigration.DatabaseMigrationException
 import org.h2.Driver

--- a/grace-plugin-database-migration/src/test/groovy/org/grails/plugins/databasemigration/command/DbmDropAllCommandSpec.groovy
+++ b/grace-plugin-database-migration/src/test/groovy/org/grails/plugins/databasemigration/command/DbmDropAllCommandSpec.groovy
@@ -1,11 +1,11 @@
 /*
- * Copyright 2015 original authors
+ * Copyright 2015-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -15,7 +15,7 @@
  */
 package org.grails.plugins.databasemigration.command
 
-import grails.cli.commands.ApplicationCommand
+import grails.cli.command.ApplicationCommand
 
 class DbmDropAllCommandSpec extends ApplicationContextDatabaseMigrationCommandSpec {
 

--- a/grace-plugin-database-migration/src/test/groovy/org/grails/plugins/databasemigration/command/DbmFutureRollbackCountSqlCommandSpec.groovy
+++ b/grace-plugin-database-migration/src/test/groovy/org/grails/plugins/databasemigration/command/DbmFutureRollbackCountSqlCommandSpec.groovy
@@ -1,11 +1,11 @@
 /*
- * Copyright 2015 original authors
+ * Copyright 2015-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -15,7 +15,7 @@
  */
 package org.grails.plugins.databasemigration.command
 
-import grails.cli.commands.ApplicationCommand
+import grails.cli.command.ApplicationCommand
 import org.grails.plugins.databasemigration.DatabaseMigrationException
 import spock.lang.AutoCleanup
 

--- a/grace-plugin-database-migration/src/test/groovy/org/grails/plugins/databasemigration/command/DbmFutureRollbackSqlCommandSpec.groovy
+++ b/grace-plugin-database-migration/src/test/groovy/org/grails/plugins/databasemigration/command/DbmFutureRollbackSqlCommandSpec.groovy
@@ -1,11 +1,11 @@
 /*
- * Copyright 2015 original authors
+ * Copyright 2015-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -15,7 +15,7 @@
  */
 package org.grails.plugins.databasemigration.command
 
-import grails.cli.commands.ApplicationCommand
+import grails.cli.command.ApplicationCommand
 import spock.lang.AutoCleanup
 
 class DbmFutureRollbackSqlCommandSpec extends ApplicationContextDatabaseMigrationCommandSpec {

--- a/grace-plugin-database-migration/src/test/groovy/org/grails/plugins/databasemigration/command/DbmGenerateChangelogCommandSpec.groovy
+++ b/grace-plugin-database-migration/src/test/groovy/org/grails/plugins/databasemigration/command/DbmGenerateChangelogCommandSpec.groovy
@@ -1,11 +1,11 @@
 /*
- * Copyright 2015 original authors
+ * Copyright 2015-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -15,7 +15,7 @@
  */
 package org.grails.plugins.databasemigration.command
 
-import grails.cli.commands.ApplicationCommand
+import grails.cli.command.ApplicationCommand
 
 class DbmGenerateChangelogCommandSpec extends ApplicationContextDatabaseMigrationCommandSpec {
 

--- a/grace-plugin-database-migration/src/test/groovy/org/grails/plugins/databasemigration/command/DbmGenerateGormChangelogCommandSpec.groovy
+++ b/grace-plugin-database-migration/src/test/groovy/org/grails/plugins/databasemigration/command/DbmGenerateGormChangelogCommandSpec.groovy
@@ -1,11 +1,11 @@
 /*
- * Copyright 2015 original authors
+ * Copyright 2015-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -15,7 +15,7 @@
  */
 package org.grails.plugins.databasemigration.command
 
-import grails.cli.commands.ApplicationCommand
+import grails.cli.command.ApplicationCommand
 import org.grails.plugins.databasemigration.DatabaseMigrationException
 
 class DbmGenerateGormChangelogCommandSpec extends ApplicationContextDatabaseMigrationCommandSpec {

--- a/grace-plugin-database-migration/src/test/groovy/org/grails/plugins/databasemigration/command/DbmGormDiffCommandSpec.groovy
+++ b/grace-plugin-database-migration/src/test/groovy/org/grails/plugins/databasemigration/command/DbmGormDiffCommandSpec.groovy
@@ -1,11 +1,11 @@
 /*
- * Copyright 2015 original authors
+ * Copyright 2015-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -15,7 +15,7 @@
  */
 package org.grails.plugins.databasemigration.command
 
-import grails.cli.commands.ApplicationCommand
+import grails.cli.command.ApplicationCommand
 import org.grails.plugins.databasemigration.DatabaseMigrationException
 
 class DbmGormDiffCommandSpec extends ApplicationContextDatabaseMigrationCommandSpec {

--- a/grace-plugin-database-migration/src/test/groovy/org/grails/plugins/databasemigration/command/DbmListLocksCommandSpec.groovy
+++ b/grace-plugin-database-migration/src/test/groovy/org/grails/plugins/databasemigration/command/DbmListLocksCommandSpec.groovy
@@ -1,11 +1,11 @@
 /*
- * Copyright 2015 original authors
+ * Copyright 2015-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -15,7 +15,7 @@
  */
 package org.grails.plugins.databasemigration.command
 
-import grails.cli.commands.ApplicationCommand
+import grails.cli.command.ApplicationCommand
 import spock.lang.AutoCleanup
 
 class DbmListLocksCommandSpec extends ApplicationContextDatabaseMigrationCommandSpec {

--- a/grace-plugin-database-migration/src/test/groovy/org/grails/plugins/databasemigration/command/DbmMarkNextChangesetRanCommandSpec.groovy
+++ b/grace-plugin-database-migration/src/test/groovy/org/grails/plugins/databasemigration/command/DbmMarkNextChangesetRanCommandSpec.groovy
@@ -1,11 +1,11 @@
 /*
- * Copyright 2015 original authors
+ * Copyright 2015-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -15,7 +15,7 @@
  */
 package org.grails.plugins.databasemigration.command
 
-import grails.cli.commands.ApplicationCommand
+import grails.cli.command.ApplicationCommand
 
 class DbmMarkNextChangesetRanCommandSpec extends ApplicationContextDatabaseMigrationCommandSpec {
 

--- a/grace-plugin-database-migration/src/test/groovy/org/grails/plugins/databasemigration/command/DbmMarkNextChangesetRanSqlCommandSpec.groovy
+++ b/grace-plugin-database-migration/src/test/groovy/org/grails/plugins/databasemigration/command/DbmMarkNextChangesetRanSqlCommandSpec.groovy
@@ -1,11 +1,11 @@
 /*
- * Copyright 2015 original authors
+ * Copyright 2015-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -15,7 +15,7 @@
  */
 package org.grails.plugins.databasemigration.command
 
-import grails.cli.commands.ApplicationCommand
+import grails.cli.command.ApplicationCommand
 import spock.lang.AutoCleanup
 
 class DbmMarkNextChangesetRanSqlCommandSpec extends ApplicationContextDatabaseMigrationCommandSpec {

--- a/grace-plugin-database-migration/src/test/groovy/org/grails/plugins/databasemigration/command/DbmPreviousChangesetSqlCommandSpec.groovy
+++ b/grace-plugin-database-migration/src/test/groovy/org/grails/plugins/databasemigration/command/DbmPreviousChangesetSqlCommandSpec.groovy
@@ -1,6 +1,21 @@
+/*
+ * Copyright 2015-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.grails.plugins.databasemigration.command
 
-import grails.cli.commands.ApplicationCommand
+import grails.cli.command.ApplicationCommand
 import org.grails.plugins.databasemigration.DatabaseMigrationException
 import spock.lang.AutoCleanup
 

--- a/grace-plugin-database-migration/src/test/groovy/org/grails/plugins/databasemigration/command/DbmReleaseLocksCommandSpec.groovy
+++ b/grace-plugin-database-migration/src/test/groovy/org/grails/plugins/databasemigration/command/DbmReleaseLocksCommandSpec.groovy
@@ -1,11 +1,11 @@
 /*
- * Copyright 2015 original authors
+ * Copyright 2015-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -15,7 +15,7 @@
  */
 package org.grails.plugins.databasemigration.command
 
-import grails.cli.commands.ApplicationCommand
+import grails.cli.command.ApplicationCommand
 
 class DbmReleaseLocksCommandSpec extends ApplicationContextDatabaseMigrationCommandSpec {
 

--- a/grace-plugin-database-migration/src/test/groovy/org/grails/plugins/databasemigration/command/DbmRollbackCommandSpec.groovy
+++ b/grace-plugin-database-migration/src/test/groovy/org/grails/plugins/databasemigration/command/DbmRollbackCommandSpec.groovy
@@ -1,11 +1,11 @@
 /*
- * Copyright 2015 original authors
+ * Copyright 2015-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -15,7 +15,7 @@
  */
 package org.grails.plugins.databasemigration.command
 
-import grails.cli.commands.ApplicationCommand
+import grails.cli.command.ApplicationCommand
 import org.grails.plugins.databasemigration.DatabaseMigrationException
 
 class DbmRollbackCommandSpec extends ApplicationContextDatabaseMigrationCommandSpec {

--- a/grace-plugin-database-migration/src/test/groovy/org/grails/plugins/databasemigration/command/DbmRollbackCountCommandSpec.groovy
+++ b/grace-plugin-database-migration/src/test/groovy/org/grails/plugins/databasemigration/command/DbmRollbackCountCommandSpec.groovy
@@ -1,11 +1,11 @@
 /*
- * Copyright 2015 original authors
+ * Copyright 2015-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -15,7 +15,7 @@
  */
 package org.grails.plugins.databasemigration.command
 
-import grails.cli.commands.ApplicationCommand
+import grails.cli.command.ApplicationCommand
 import org.grails.plugins.databasemigration.DatabaseMigrationException
 
 class DbmRollbackCountCommandSpec extends ApplicationContextDatabaseMigrationCommandSpec {

--- a/grace-plugin-database-migration/src/test/groovy/org/grails/plugins/databasemigration/command/DbmRollbackCountSqlCommandSpec.groovy
+++ b/grace-plugin-database-migration/src/test/groovy/org/grails/plugins/databasemigration/command/DbmRollbackCountSqlCommandSpec.groovy
@@ -1,11 +1,11 @@
 /*
- * Copyright 2015 original authors
+ * Copyright 2015-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -15,7 +15,7 @@
  */
 package org.grails.plugins.databasemigration.command
 
-import grails.cli.commands.ApplicationCommand
+import grails.cli.command.ApplicationCommand
 import org.grails.plugins.databasemigration.DatabaseMigrationException
 import spock.lang.AutoCleanup
 

--- a/grace-plugin-database-migration/src/test/groovy/org/grails/plugins/databasemigration/command/DbmRollbackSqlCommandSpec.groovy
+++ b/grace-plugin-database-migration/src/test/groovy/org/grails/plugins/databasemigration/command/DbmRollbackSqlCommandSpec.groovy
@@ -1,11 +1,11 @@
 /*
- * Copyright 2015 original authors
+ * Copyright 2015-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -15,7 +15,7 @@
  */
 package org.grails.plugins.databasemigration.command
 
-import grails.cli.commands.ApplicationCommand
+import grails.cli.command.ApplicationCommand
 import org.grails.plugins.databasemigration.DatabaseMigrationException
 import spock.lang.AutoCleanup
 

--- a/grace-plugin-database-migration/src/test/groovy/org/grails/plugins/databasemigration/command/DbmRollbackToDateCommandSpec.groovy
+++ b/grace-plugin-database-migration/src/test/groovy/org/grails/plugins/databasemigration/command/DbmRollbackToDateCommandSpec.groovy
@@ -1,11 +1,11 @@
 /*
- * Copyright 2015 original authors
+ * Copyright 2015-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -15,7 +15,7 @@
  */
 package org.grails.plugins.databasemigration.command
 
-import grails.cli.commands.ApplicationCommand
+import grails.cli.command.ApplicationCommand
 import org.grails.plugins.databasemigration.DatabaseMigrationException
 
 class DbmRollbackToDateCommandSpec extends ApplicationContextDatabaseMigrationCommandSpec {

--- a/grace-plugin-database-migration/src/test/groovy/org/grails/plugins/databasemigration/command/DbmRollbackToDateSqlCommandSpec.groovy
+++ b/grace-plugin-database-migration/src/test/groovy/org/grails/plugins/databasemigration/command/DbmRollbackToDateSqlCommandSpec.groovy
@@ -1,11 +1,11 @@
 /*
- * Copyright 2015 original authors
+ * Copyright 2015-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -15,7 +15,7 @@
  */
 package org.grails.plugins.databasemigration.command
 
-import grails.cli.commands.ApplicationCommand
+import grails.cli.command.ApplicationCommand
 import org.grails.plugins.databasemigration.DatabaseMigrationException
 import spock.lang.AutoCleanup
 

--- a/grace-plugin-database-migration/src/test/groovy/org/grails/plugins/databasemigration/command/DbmStatusCommandSpec.groovy
+++ b/grace-plugin-database-migration/src/test/groovy/org/grails/plugins/databasemigration/command/DbmStatusCommandSpec.groovy
@@ -1,11 +1,11 @@
 /*
- * Copyright 2015 original authors
+ * Copyright 2015-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -15,7 +15,7 @@
  */
 package org.grails.plugins.databasemigration.command
 
-import grails.cli.commands.ApplicationCommand
+import grails.cli.command.ApplicationCommand
 import spock.lang.AutoCleanup
 
 class DbmStatusCommandSpec extends ApplicationContextDatabaseMigrationCommandSpec {

--- a/grace-plugin-database-migration/src/test/groovy/org/grails/plugins/databasemigration/command/DbmUpdateCommandSpec.groovy
+++ b/grace-plugin-database-migration/src/test/groovy/org/grails/plugins/databasemigration/command/DbmUpdateCommandSpec.groovy
@@ -1,11 +1,11 @@
 /*
- * Copyright 2015 original authors
+ * Copyright 2015-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -15,7 +15,7 @@
  */
 package org.grails.plugins.databasemigration.command
 
-import grails.cli.commands.ApplicationCommand
+import grails.cli.command.ApplicationCommand
 
 class DbmUpdateCommandSpec extends ApplicationContextDatabaseMigrationCommandSpec {
 

--- a/grace-plugin-database-migration/src/test/groovy/org/grails/plugins/databasemigration/command/DbmUpdateCountCommandSpec.groovy
+++ b/grace-plugin-database-migration/src/test/groovy/org/grails/plugins/databasemigration/command/DbmUpdateCountCommandSpec.groovy
@@ -1,11 +1,11 @@
 /*
- * Copyright 2015 original authors
+ * Copyright 2015-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -15,7 +15,7 @@
  */
 package org.grails.plugins.databasemigration.command
 
-import grails.cli.commands.ApplicationCommand
+import grails.cli.command.ApplicationCommand
 import org.grails.plugins.databasemigration.DatabaseMigrationException
 
 class DbmUpdateCountCommandSpec extends ApplicationContextDatabaseMigrationCommandSpec {

--- a/grace-plugin-database-migration/src/test/groovy/org/grails/plugins/databasemigration/command/DbmUpdateCountSqlCommandSpec.groovy
+++ b/grace-plugin-database-migration/src/test/groovy/org/grails/plugins/databasemigration/command/DbmUpdateCountSqlCommandSpec.groovy
@@ -1,11 +1,11 @@
 /*
- * Copyright 2015 original authors
+ * Copyright 2015-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -15,7 +15,7 @@
  */
 package org.grails.plugins.databasemigration.command
 
-import grails.cli.commands.ApplicationCommand
+import grails.cli.command.ApplicationCommand
 import org.grails.plugins.databasemigration.DatabaseMigrationException
 import spock.lang.AutoCleanup
 

--- a/grace-plugin-database-migration/src/test/groovy/org/grails/plugins/databasemigration/command/DbmUpdateSqlCommandSpec.groovy
+++ b/grace-plugin-database-migration/src/test/groovy/org/grails/plugins/databasemigration/command/DbmUpdateSqlCommandSpec.groovy
@@ -1,11 +1,11 @@
 /*
- * Copyright 2015 original authors
+ * Copyright 2015-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -15,7 +15,7 @@
  */
 package org.grails.plugins.databasemigration.command
 
-import grails.cli.commands.ApplicationCommand
+import grails.cli.command.ApplicationCommand
 import spock.lang.AutoCleanup
 
 class DbmUpdateSqlCommandSpec extends ApplicationContextDatabaseMigrationCommandSpec {

--- a/grace-plugin-database-migration/src/test/groovy/org/grails/plugins/databasemigration/command/DbmValidateCommandSpec.groovy
+++ b/grace-plugin-database-migration/src/test/groovy/org/grails/plugins/databasemigration/command/DbmValidateCommandSpec.groovy
@@ -1,11 +1,11 @@
 /*
- * Copyright 2015 original authors
+ * Copyright 2015-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -15,7 +15,7 @@
  */
 package org.grails.plugins.databasemigration.command
 
-import grails.cli.commands.ApplicationCommand
+import grails.cli.command.ApplicationCommand
 import liquibase.exception.ChangeLogParseException
 
 class DbmValidateCommandSpec extends ApplicationContextDatabaseMigrationCommandSpec {

--- a/grace-plugin-url-mappings/src/main/groovy/org/grails/web/mapping/reporting/UrlMappingsReportCommand.groovy
+++ b/grace-plugin-url-mappings/src/main/groovy/org/grails/web/mapping/reporting/UrlMappingsReportCommand.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2026 the original author or authors.
+ * Copyright 2015-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,8 +19,8 @@ import groovy.transform.CompileStatic
 import groovy.transform.EqualsAndHashCode
 import groovy.util.logging.Commons
 
-import grails.cli.commands.ApplicationCommand
-import grails.cli.commands.ExecutionContext
+import grails.cli.command.ApplicationCommand
+import grails.cli.command.ExecutionContext
 import grails.web.mapping.UrlMappings
 import grails.web.mapping.reporting.UrlMappingsRenderer
 

--- a/grace-plugin-url-mappings/src/main/resources/META-INF/grails.factories
+++ b/grace-plugin-url-mappings/src/main/resources/META-INF/grails.factories
@@ -1,5 +1,5 @@
 grails.core.ArtefactHandler=\
 org.grails.core.artefact.UrlMappingsArtefactHandler
 
-grails.cli.commands.ApplicationCommand=\
+grails.cli.command.ApplicationCommand=\
 org.grails.web.mapping.reporting.UrlMappingsReportCommand

--- a/grace-shell/src/main/groovy/org/grails/cli/command/factory/ApplicationContextCommandFactory.groovy
+++ b/grace-shell/src/main/groovy/org/grails/cli/command/factory/ApplicationContextCommandFactory.groovy
@@ -17,7 +17,6 @@ package org.grails.cli.command.factory
 
 import grails.build.logging.GrailsConsole
 import grails.cli.command.ApplicationCommand
-import grails.util.Named
 
 import org.grails.cli.command.Command
 import org.grails.cli.command.gradle.GradleTaskCommandAdapter
@@ -38,7 +37,7 @@ class ApplicationContextCommandFactory implements CommandFactory {
             ClassLoader classLoader = Thread.currentThread().contextClassLoader
             List<ApplicationCommand> registeredCommands = GrailsFactoriesLoader.loadFactories(ApplicationCommand, classLoader)
 
-            return registeredCommands.collect { Named named -> new GradleTaskCommandAdapter(named) }
+            return registeredCommands.collect { ApplicationCommand command -> new GradleTaskCommandAdapter(command) }
         }
         catch (Throwable e) {
             GrailsConsole.instance.error("Error occurred loading commands: $e.message", e)

--- a/grace-shell/src/main/groovy/org/grails/cli/command/factory/ApplicationContextCommandFactory.groovy
+++ b/grace-shell/src/main/groovy/org/grails/cli/command/factory/ApplicationContextCommandFactory.groovy
@@ -16,7 +16,7 @@
 package org.grails.cli.command.factory
 
 import grails.build.logging.GrailsConsole
-import grails.cli.commands.ApplicationCommand
+import grails.cli.command.ApplicationCommand
 import grails.util.Named
 
 import org.grails.cli.command.Command

--- a/grace-shell/src/main/groovy/org/grails/cli/command/gradle/GradleTaskCommandAdapter.groovy
+++ b/grace-shell/src/main/groovy/org/grails/cli/command/gradle/GradleTaskCommandAdapter.groovy
@@ -18,17 +18,17 @@ package org.grails.cli.command.gradle
 import groovy.transform.CompileDynamic
 import groovy.transform.CompileStatic
 
-import grails.util.Described
+import grails.cli.command.ApplicationCommand
 import grails.util.GrailsNameUtils
-import grails.util.Named
 
+import org.grails.build.parsing.CommandLine
 import org.grails.cli.command.CommandDescription
 import org.grails.cli.command.ExecutionContext
 import org.grails.cli.command.ProjectCommand
 import org.grails.cli.gradle.GradleInvoker
 
 /**
- * Adapts a {@link Named} command into a Gradle task execution
+ * Adapts a {@link ApplicationCommand} command into a Gradle task execution
  *
  * @author Graeme Rocher
  * @author Michael Yan
@@ -37,31 +37,24 @@ import org.grails.cli.gradle.GradleInvoker
 @CompileStatic
 class GradleTaskCommandAdapter implements ProjectCommand {
 
-    final Named adapted
+    final ApplicationCommand applicationCommand
 
-    GradleTaskCommandAdapter(Named adapted) {
-        this.adapted = adapted
+    GradleTaskCommandAdapter(ApplicationCommand command) {
+        this.applicationCommand = command
     }
 
     @Override
     CommandDescription getDescription() {
-        String description
-        if (adapted instanceof Described) {
-            description = ((Described) adapted).description
-        }
-        else {
-            description = ''
-        }
-        new CommandDescription(adapted.name, description)
+        new CommandDescription(this.applicationCommand.name, this.applicationCommand.description)
     }
 
     @Override
     @CompileDynamic
     boolean handle(ExecutionContext executionContext) {
         GradleInvoker invoker = new GradleInvoker(executionContext)
-        String method = GrailsNameUtils.getPropertyNameForLowerCaseHyphenSeparatedName(adapted.name)
+        String method = GrailsNameUtils.getPropertyNameForLowerCaseHyphenSeparatedName(this.applicationCommand.name)
 
-        def commandLine = executionContext.commandLine
+        CommandLine commandLine = executionContext.commandLine
         if (commandLine.remainingArgs || commandLine.undeclaredOptions) {
             invoker."${method}"("-Pargs=${commandLine.remainingArgsWithOptionsString}")
         }
@@ -74,7 +67,7 @@ class GradleTaskCommandAdapter implements ProjectCommand {
 
     @Override
     String getName() {
-        adapted.name
+        this.applicationCommand.name
     }
 
     @Override


### PR DESCRIPTION
- Rename package name of grace-cli from `grails.cli.commands` to `grails.cli.command`
- Enhance `ApplicationCommand`
  - Recommend to use `ApplicationCommand` instead of `GrailsApplicationCommand`
- Make `GradleTaskCommandAdapter` directly adapted with `ApplicationCommand`