### PR TITLE
Improve Gradle assemble task

### DIFF
--- a/buildSrc/src/main/groovy/org/grails/gradle/GraceCreateStartScripts.groovy
+++ b/buildSrc/src/main/groovy/org/grails/gradle/GraceCreateStartScripts.groovy
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2012-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.grails.gradle
+
+import org.gradle.api.resources.TextResource
+import org.gradle.api.tasks.Internal
+import org.gradle.api.tasks.TaskAction
+import org.gradle.api.tasks.application.CreateStartScripts
+import org.gradle.work.DisableCachingByDefault
+
+/**
+ * Creates start scripts for launching Grace Shell applications.
+ *
+ * @author Michael Yan
+ * @since 2024.2.0
+ */
+@DisableCachingByDefault(
+        because = "Not worth caching"
+)
+abstract class GraceCreateStartScripts extends CreateStartScripts {
+
+    @Internal
+    TextResource unixStartScriptTemplate
+
+    @Internal
+    TextResource windowsStartScriptTemplate
+
+    @Internal
+    Collection<String> projectArtifacts = []
+
+    GraceCreateStartScripts() {
+        setDescription('Creates OS specific scripts to run grace-shell as a JVM application.')
+        mainClass.set('org.grails.cli.GrailsCli')
+        applicationName = 'grace'
+    }
+
+    @TaskAction
+    void generate() {
+        def generator = new org.gradle.api.internal.plugins.StartScriptGenerator()
+        generator.unixStartScriptGenerator.template = unixStartScriptTemplate
+        generator.windowsStartScriptGenerator.template = windowsStartScriptTemplate
+        generator.applicationName = getApplicationName()
+        generator.mainClassName = getMainClass().get()
+        generator.defaultJvmOpts = getDefaultJvmOpts()
+        generator.optsEnvironmentVar = getOptsEnvironmentVar()
+        generator.exitEnvironmentVar = getExitEnvironmentVar()
+        generator.classpath = projectArtifacts + getClasspath().resolvedConfiguration.resolvedArtifacts.collect { artifact ->
+            def dependency = artifact.moduleVersion.id
+            String installedFile = "lib/$dependency.group/$dependency.name/jars/$artifact.file.name"
+            if (dependency.group == 'org.graceframework') {
+                installedFile = "dist/$artifact.file.name"
+            }
+            installedFile
+        }
+        generator.scriptRelPath = "bin/${getUnixScript().name}"
+        generator.generateUnixScript(getUnixScript())
+        generator.generateWindowsScript(getWindowsScript())
+    }
+
+}

--- a/gradle/assemble.gradle
+++ b/gradle/assemble.gradle
@@ -28,7 +28,7 @@ abstract class GrailsCreateStartScripts extends org.gradle.api.tasks.application
     }
 }
 
-task grailsCreateStartScripts(type: GrailsCreateStartScripts) {
+tasks.register('grailsCreateStartScripts', GrailsCreateStartScripts) {
     description = "Creates OS specific scripts to run grace-shell as a JVM application."
     mainClass = 'org.grails.cli.GrailsCli'
     applicationName = 'grace'
@@ -55,27 +55,29 @@ task grailsCreateStartScripts(type: GrailsCreateStartScripts) {
     }
 }
 
-task install(dependsOn: grailsCreateStartScripts) { task ->
+tasks.register('install') {
+    dependsOn = [grailsCreateStartScripts]
     subprojects { Project project ->
         if(project.name != 'docs' && !project.name.startsWith('grace-test-suite')) {
-            task.dependsOn("$project.name:publishToMavenLocal")
+            dependsOn("$project.name:publishToMavenLocal")
         }
     }
 }
 
-task publishToDist { task ->
+tasks.register('publishToDist') {
     subprojects { Project project ->
         if (project.name != 'docs' && !project.name.startsWith('grace-test-suite') && !project.name.startsWith('grace-dependencies') && !project.name.startsWith('grace-bom')) {
             project.tasks.named("generateMetadataFileForIvyPublication").configure {
                 enabled = false
             }
-            task.dependsOn("$project.name:publishAllPublicationsToGraceDistRepository")
+            dependsOn("$project.name:publishAllPublicationsToGraceDistRepository")
         }
     }
 }
 
-task binZip(type: Zip, dependsOn: [publishToDist, grailsCreateStartScripts]) {
-    destinationDirectory = "${buildDir}/distributions" as File
+tasks.register('binZip', Zip) {
+    dependsOn = [publishToDist, grailsCreateStartScripts]
+    destinationDirectory = rootProject.layout.buildDirectory.dir('distributions')
     archiveBaseName = 'grace'
     archiveAppendix = grailsVersion
     archiveClassifier = 'bin'
@@ -102,8 +104,9 @@ task binZip(type: Zip, dependsOn: [publishToDist, grailsCreateStartScripts]) {
     }
 }
 
-task sourcesZip(type: Zip, dependsOn: [publishToDist]) {
-    destinationDirectory = "${buildDir}/distributions" as File
+tasks.register('sourcesZip', Zip) {
+    dependsOn = [publishToDist]
+    destinationDirectory = rootProject.layout.buildDirectory.dir('distributions')
     archiveBaseName = 'grace'
     archiveAppendix = grailsVersion
     archiveClassifier = 'sources'
@@ -119,8 +122,9 @@ task sourcesZip(type: Zip, dependsOn: [publishToDist]) {
     }
 }
 
-task docsZip(type: Zip, dependsOn: ['docs:docs']) {
-    destinationDirectory = "${buildDir}/distributions" as File
+tasks.register('docsZip', Zip) {
+    dependsOn = ['docs:docs']
+    destinationDirectory = rootProject.layout.buildDirectory.dir('distributions')
     archiveBaseName = 'grace'
     archiveAppendix = grailsVersion
     archiveClassifier = 'docs'
@@ -135,6 +139,10 @@ task docsZip(type: Zip, dependsOn: ['docs:docs']) {
     }
 }
 
-task zipDist(dependsOn: [binZip, sourcesZip, docsZip])
+tasks.register('zipDist') {
+    dependsOn = [binZip, sourcesZip, docsZip]
+}
 
-task assemble(dependsOn: [install, zipDist])
+tasks.register('assemble') {
+    dependsOn = [install, zipDist]
+}

--- a/gradle/assemble.gradle
+++ b/gradle/assemble.gradle
@@ -1,61 +1,6 @@
 // Gradle assemble tasks
 
-def libsConfigurations = []
-subprojects { subproject ->
-    if (subproject.name == 'grace-dependencies') return
-    if (subproject.name == 'grace-bom') return
-    if (subproject.name == 'grace-shell') {
-        configurations {
-            libsConfigurations << libs {
-                extendsFrom runtimeClasspath
-                attributes {
-                    attribute(Usage.USAGE_ATTRIBUTE, subproject.objects.named(Usage, Usage.JAVA_RUNTIME))
-                    attribute(Category.CATEGORY_ATTRIBUTE, subproject.objects.named(Category, Category.LIBRARY))
-                }
-            }
-        }
-    }
-}
-
-task configurePopulateDependencies(dependsOn: 'publishToDist') {
-    doLast {
-        def projectNames = rootProject.subprojects*.name
-
-        def seen = []
-        libsConfigurations.each { configuration ->
-            for (artifact in configuration.resolvedConfiguration.resolvedArtifacts) {
-                if (artifact in seen) continue
-                seen << artifact
-                def dependency = artifact.moduleVersion.id
-                if (!projectNames.contains(dependency.name)) {
-                    if (dependency.group == 'org.graceframework') {
-                        populateDependencies.into('org.graceframework') {
-                            from artifact.file // this will trigger the actual download if necessary
-                        }
-                    } else {
-                        populateDependencies.into("$dependency.group/$dependency.name/jars") {
-                            from artifact.file // this will trigger the actual download if necessary
-                        }
-                    }
-                } else {
-                    populateDependencies.into('org.graceframework') {
-                        from(homeDistDir) {
-                            include artifact.file.name
-                        }
-                    }
-                }
-            }
-        }
-    }
-}
-
-task populateDependencies(type: Sync, dependsOn: configurePopulateDependencies) {
-    duplicatesStrategy = DuplicatesStrategy.EXCLUDE
-    into homeLibDir
-    includeEmptyDirs = false
-}
-
-task grailsCreateStartScripts(type: GrailsCreateStartScripts, dependsOn: populateDependencies) {
+task grailsCreateStartScripts(type: GrailsCreateStartScripts) {
     description = "Creates OS specific scripts to run grace-shell as a JVM application."
     mainClass = 'org.grails.cli.GrailsCli'
     applicationName = 'grace'
@@ -68,6 +13,17 @@ task grailsCreateStartScripts(type: GrailsCreateStartScripts, dependsOn: populat
         ant.replace(file: file('bin/grace.bat'), token: 'APP_HOME', value: 'GRACE_HOME')
         ant.replace(file: file('bin/grace'), token: 'media/gradle.icns', value: 'media/icons/grace.icns')
         ant.chmod(file: file('bin/grace'), perm: 'ugo+rx')
+
+        def resolvedArtifacts = rootProject.childProjects['grace-shell']
+                .configurations.runtimeClasspath.resolvedConfiguration.resolvedArtifacts
+        for (artifact in resolvedArtifacts) {
+            def dependency = artifact.moduleVersion.id
+            if (dependency.group == 'org.graceframework') {
+                ant.copy(file: artifact.file, todir: "${homeLibDir}/org.graceframework")
+            } else {
+                ant.copy(file: artifact.file, todir: "${homeLibDir}/${dependency.group}/${dependency.name}/jars")
+            }
+        }
     }
 }
 
@@ -99,7 +55,7 @@ class GrailsCreateStartScripts extends org.gradle.api.tasks.application.CreateSt
     }
 }
 
-task install(dependsOn: populateDependencies) { task ->
+task install(dependsOn: grailsCreateStartScripts) { task ->
     subprojects { Project project ->
         if(project.name != 'docs' && !project.name.startsWith('grace-test-suite')) {
             task.dependsOn("$project.name:publishToMavenLocal")
@@ -118,7 +74,7 @@ task publishToDist { task ->
     }
 }
 
-task binZip(type: Zip, dependsOn: [publishToDist, populateDependencies, grailsCreateStartScripts]) {
+task binZip(type: Zip, dependsOn: [publishToDist, grailsCreateStartScripts]) {
     destinationDirectory = "${buildDir}/distributions" as File
     archiveBaseName = 'grace'
     archiveAppendix = grailsVersion

--- a/gradle/assemble.gradle
+++ b/gradle/assemble.gradle
@@ -1,33 +1,6 @@
 // Gradle assemble tasks
 
-task grailsCreateStartScripts(type: GrailsCreateStartScripts) {
-    description = "Creates OS specific scripts to run grace-shell as a JVM application."
-    mainClass = 'org.grails.cli.GrailsCli'
-    applicationName = 'grace'
-    defaultJvmOpts = ["-XX:+TieredCompilation", "-XX:TieredStopAtLevel=1", "-XX:CICompilerCount=3"]
-    outputDir = file('bin')
-    classpath = rootProject.childProjects['grace-shell'].configurations.runtimeClasspath
-    projectArtifacts = rootProject.childProjects['grace-shell'].tasks['jar'].outputs.files.collect { "dist/${it.name}" }
-    doLast {
-        ant.replace(file: file('bin/grace'), token: 'APP_HOME', value: 'GRACE_HOME')
-        ant.replace(file: file('bin/grace.bat'), token: 'APP_HOME', value: 'GRACE_HOME')
-        ant.replace(file: file('bin/grace'), token: 'media/gradle.icns', value: 'media/icons/grace.icns')
-        ant.chmod(file: file('bin/grace'), perm: 'ugo+rx')
-
-        def resolvedArtifacts = rootProject.childProjects['grace-shell']
-                .configurations.runtimeClasspath.resolvedConfiguration.resolvedArtifacts
-        for (artifact in resolvedArtifacts) {
-            def dependency = artifact.moduleVersion.id
-            if (dependency.group == 'org.graceframework') {
-                ant.copy(file: artifact.file, todir: "${homeLibDir}/org.graceframework")
-            } else {
-                ant.copy(file: artifact.file, todir: "${homeLibDir}/${dependency.group}/${dependency.name}/jars")
-            }
-        }
-    }
-}
-
-class GrailsCreateStartScripts extends org.gradle.api.tasks.application.CreateStartScripts {
+abstract class GrailsCreateStartScripts extends org.gradle.api.tasks.application.CreateStartScripts {
     @org.gradle.api.tasks.Internal
     Collection<String> projectArtifacts=[]
 
@@ -52,6 +25,33 @@ class GrailsCreateStartScripts extends org.gradle.api.tasks.application.CreateSt
         generator.scriptRelPath = "bin/${getUnixScript().name}"
         generator.generateUnixScript(getUnixScript())
         generator.generateWindowsScript(getWindowsScript())
+    }
+}
+
+task grailsCreateStartScripts(type: GrailsCreateStartScripts) {
+    description = "Creates OS specific scripts to run grace-shell as a JVM application."
+    mainClass = 'org.grails.cli.GrailsCli'
+    applicationName = 'grace'
+    defaultJvmOpts = ["-XX:+TieredCompilation", "-XX:TieredStopAtLevel=1", "-XX:CICompilerCount=3"]
+    outputDir = file('bin')
+    classpath = rootProject.childProjects['grace-shell'].configurations.runtimeClasspath
+    projectArtifacts = rootProject.childProjects['grace-shell'].tasks['jar'].outputs.files.collect { "dist/${it.name}" }
+    doLast {
+        ant.replace(file: file('bin/grace'), token: 'APP_HOME', value: 'GRACE_HOME')
+        ant.replace(file: file('bin/grace.bat'), token: 'APP_HOME', value: 'GRACE_HOME')
+        ant.replace(file: file('bin/grace'), token: 'media/gradle.icns', value: 'media/icons/grace.icns')
+        ant.chmod(file: file('bin/grace'), perm: 'ugo+rx')
+
+        def resolvedArtifacts = rootProject.childProjects['grace-shell']
+                .configurations.runtimeClasspath.resolvedConfiguration.resolvedArtifacts
+        for (artifact in resolvedArtifacts) {
+            def dependency = artifact.moduleVersion.id
+            if (dependency.group == 'org.graceframework') {
+                ant.copy(file: artifact.file, todir: "${homeLibDir}/org.graceframework")
+            } else {
+                ant.copy(file: artifact.file, todir: "${homeLibDir}/${dependency.group}/${dependency.name}/jars")
+            }
+        }
     }
 }
 

--- a/gradle/assemble.gradle
+++ b/gradle/assemble.gradle
@@ -1,48 +1,14 @@
 // Gradle assemble tasks
+import org.grails.gradle.GraceCreateStartScripts
 
-abstract class GrailsCreateStartScripts extends org.gradle.api.tasks.application.CreateStartScripts {
-    @org.gradle.api.tasks.Internal
-    org.gradle.api.resources.TextResource unixStartScriptTemplate
-    @org.gradle.api.tasks.Internal
-    org.gradle.api.resources.TextResource windowsStartScriptTemplate
-
-    @org.gradle.api.tasks.Internal
-    Collection<String> projectArtifacts = []
-
-    @org.gradle.api.tasks.TaskAction
-    void generate() {
-        def generator = new org.gradle.api.internal.plugins.StartScriptGenerator()
-        generator.unixStartScriptGenerator.template = unixStartScriptTemplate
-        generator.windowsStartScriptGenerator.template = windowsStartScriptTemplate
-        generator.applicationName = getApplicationName()
-        generator.mainClassName = getMainClass().get()
-        generator.defaultJvmOpts = getDefaultJvmOpts()
-        generator.optsEnvironmentVar = getOptsEnvironmentVar()
-        generator.exitEnvironmentVar = getExitEnvironmentVar()
-        generator.classpath = projectArtifacts + getClasspath().resolvedConfiguration.resolvedArtifacts.collect { artifact ->
-            def dependency = artifact.moduleVersion.id
-            String installedFile = "lib/$dependency.group/$dependency.name/jars/$artifact.file.name"
-            if (dependency.group == 'org.graceframework') {
-                installedFile = "dist/$artifact.file.name"
-            }
-            installedFile
-        }
-        generator.scriptRelPath = "bin/${getUnixScript().name}"
-        generator.generateUnixScript(getUnixScript())
-        generator.generateWindowsScript(getWindowsScript())
-    }
-}
-
-tasks.register('grailsCreateStartScripts', GrailsCreateStartScripts) {
-    description = "Creates OS specific scripts to run grace-shell as a JVM application."
-    mainClass = 'org.grails.cli.GrailsCli'
-    applicationName = 'grace'
+tasks.register('createGraceStartScripts', GraceCreateStartScripts) {
     defaultJvmOpts = ["-XX:+TieredCompilation", "-XX:TieredStopAtLevel=1", "-XX:CICompilerCount=3"]
     outputDir = file('bin')
     classpath = rootProject.childProjects['grace-shell'].configurations.runtimeClasspath
     unixStartScriptTemplate = rootProject.childProjects['grace-shell'].resources.text.fromFile('src/main/resources/unixStartScript.txt')
     windowsStartScriptTemplate = rootProject.childProjects['grace-shell'].resources.text.fromFile('src/main/resources/windowsStartScript.txt')
     projectArtifacts = rootProject.childProjects['grace-shell'].tasks['jar'].outputs.files.collect { "dist/${it.name}" }
+
     doLast {
         ant.replace(file: file('bin/grace'), token: 'APP_HOME', value: 'GRACE_HOME')
         ant.replace(file: file('bin/grace.bat'), token: 'APP_HOME', value: 'GRACE_HOME')
@@ -62,9 +28,9 @@ tasks.register('grailsCreateStartScripts', GrailsCreateStartScripts) {
 }
 
 tasks.register('install') {
-    dependsOn = [grailsCreateStartScripts]
+    dependsOn = [createGraceStartScripts]
     subprojects { Project project ->
-        if(project.name != 'docs' && !project.name.startsWith('grace-test-suite')) {
+        if (project.name != 'docs' && !project.name.startsWith('grace-test-suite')) {
             dependsOn("$project.name:publishToMavenLocal")
         }
     }
@@ -82,7 +48,7 @@ tasks.register('publishToDist') {
 }
 
 tasks.register('binZip', Zip) {
-    dependsOn = [publishToDist, grailsCreateStartScripts]
+    dependsOn = [publishToDist, createGraceStartScripts]
     destinationDirectory = rootProject.layout.buildDirectory.dir('distributions')
     archiveBaseName = 'grace'
     archiveAppendix = grailsVersion

--- a/gradle/assemble.gradle
+++ b/gradle/assemble.gradle
@@ -2,13 +2,18 @@
 
 abstract class GrailsCreateStartScripts extends org.gradle.api.tasks.application.CreateStartScripts {
     @org.gradle.api.tasks.Internal
-    Collection<String> projectArtifacts=[]
+    org.gradle.api.resources.TextResource unixStartScriptTemplate
+    @org.gradle.api.tasks.Internal
+    org.gradle.api.resources.TextResource windowsStartScriptTemplate
+
+    @org.gradle.api.tasks.Internal
+    Collection<String> projectArtifacts = []
 
     @org.gradle.api.tasks.TaskAction
     void generate() {
         def generator = new org.gradle.api.internal.plugins.StartScriptGenerator()
-        generator.unixStartScriptGenerator.template = project.rootProject.childProjects['grace-shell'].resources.text.fromFile('src/main/resources/unixStartScript.txt')
-        generator.windowsStartScriptGenerator.template = project.rootProject.childProjects['grace-shell'].resources.text.fromFile('src/main/resources/windowsStartScript.txt')
+        generator.unixStartScriptGenerator.template = unixStartScriptTemplate
+        generator.windowsStartScriptGenerator.template = windowsStartScriptTemplate
         generator.applicationName = getApplicationName()
         generator.mainClassName = getMainClass().get()
         generator.defaultJvmOpts = getDefaultJvmOpts()
@@ -35,12 +40,13 @@ tasks.register('grailsCreateStartScripts', GrailsCreateStartScripts) {
     defaultJvmOpts = ["-XX:+TieredCompilation", "-XX:TieredStopAtLevel=1", "-XX:CICompilerCount=3"]
     outputDir = file('bin')
     classpath = rootProject.childProjects['grace-shell'].configurations.runtimeClasspath
+    unixStartScriptTemplate = rootProject.childProjects['grace-shell'].resources.text.fromFile('src/main/resources/unixStartScript.txt')
+    windowsStartScriptTemplate = rootProject.childProjects['grace-shell'].resources.text.fromFile('src/main/resources/windowsStartScript.txt')
     projectArtifacts = rootProject.childProjects['grace-shell'].tasks['jar'].outputs.files.collect { "dist/${it.name}" }
     doLast {
         ant.replace(file: file('bin/grace'), token: 'APP_HOME', value: 'GRACE_HOME')
         ant.replace(file: file('bin/grace.bat'), token: 'APP_HOME', value: 'GRACE_HOME')
         ant.replace(file: file('bin/grace'), token: 'media/gradle.icns', value: 'media/icons/grace.icns')
-        ant.chmod(file: file('bin/grace'), perm: 'ugo+rx')
 
         def resolvedArtifacts = rootProject.childProjects['grace-shell']
                 .configurations.runtimeClasspath.resolvedConfiguration.resolvedArtifacts


### PR DESCRIPTION
- Gradle: remove tasks configurePopulateDependencies and populateDependencies
- Gradle: make GrailsCreateStartScripts as abstract class
- Gradle: use tasks.register() instead of deprecated create method
- Gradle: add internal properties unixStartScriptTemplate and windowsStartScriptTemplate to CreateStartScripts
- Gradle: create GraceCreateStartScripts into buildSrc to simplify the assemble.gradle